### PR TITLE
SignUp 화면: 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		142DBEDF29DC4DCE00017603 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEDE29DC4DCE00017603 /* MainTabBarController.swift */; };
 		142DBEE129DC4FC300017603 /* MainTabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */; };
 		14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */; };
+		14567E9C29DFE824000B75EE /* EmailStackViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
 		14793FA629D8046E0048D5DD /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14793FA529D8046E0048D5DD /* ColorAssets.xcassets */; };
 		14793FA929D831230048D5DD /* ExUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14793FA829D831230048D5DD /* ExUIColor.swift */; };
@@ -61,6 +62,7 @@
 		142DBEDE29DC4DCE00017603 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewModel.swift; sourceTree = "<group>"; };
 		14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellViewModel.swift; sourceTree = "<group>"; };
+		14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellModel.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
 		14793FA529D8046E0048D5DD /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
 		14793FA829D831230048D5DD /* ExUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExUIColor.swift; sourceTree = "<group>"; };
@@ -239,6 +241,7 @@
 			children = (
 				14DD370E29DB0D5B00D6A715 /* EmailStackViewCell.swift */,
 				14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */,
+				14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */,
 			);
 			path = EmailStackViewCell;
 			sourceTree = "<group>";
@@ -350,6 +353,7 @@
 			files = (
 				14793FBC29D837480048D5DD /* ExUIFont.swift in Sources */,
 				14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */,
+				14567E9C29DFE824000B75EE /* EmailStackViewCellModel.swift in Sources */,
 				147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */,
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
 				142DBEDA29DC2EEB00017603 /* SignInViewModel.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		14066BAF29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14066BAE29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift */; };
 		14066BB129E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14066BB029E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift */; };
+		14066BB329E166B100AFB2D2 /* SignUpPasswordModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14066BB229E166B100AFB2D2 /* SignUpPasswordModel.swift */; };
 		141A781829D7ED46006731F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781729D7ED46006731F7 /* AppDelegate.swift */; };
 		141A781A29D7ED46006731F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781929D7ED46006731F7 /* SceneDelegate.swift */; };
 		141A782129D7ED46006731F7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 141A782029D7ED46006731F7 /* Assets.xcassets */; };
@@ -52,6 +53,7 @@
 /* Begin PBXFileReference section */
 		14066BAE29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTextFieldCellViewModel.swift; sourceTree = "<group>"; };
 		14066BB029E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordToCheckTextFieldCellViewModel.swift; sourceTree = "<group>"; };
+		14066BB229E166B100AFB2D2 /* SignUpPasswordModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPasswordModel.swift; sourceTree = "<group>"; };
 		141A781429D7ED46006731F7 /* WanF-Project.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WanF-Project.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		141A781729D7ED46006731F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		141A781929D7ED46006731F7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 				14A1BFEE29DBE2F400351567 /* PasswordToCheckTextFieldCell */,
 				14DD371D29DB2CBB00D6A715 /* SignUpPasswordViewController.swift */,
 				14DD372329DB318900D6A715 /* SignUpPasswordViewModel.swift */,
+				14066BB229E166B100AFB2D2 /* SignUpPasswordModel.swift */,
 			);
 			path = SignUpPasswordViewController;
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 				147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */,
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
 				14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */,
+				14066BB329E166B100AFB2D2 /* SignUpPasswordModel.swift in Sources */,
 				142DBEDA29DC2EEB00017603 /* SignInViewModel.swift in Sources */,
 				14793FA929D831230048D5DD /* ExUIColor.swift in Sources */,
 				141A783629D7F1E5006731F7 /* SignInViewController.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */; };
 		14567E9C29DFE824000B75EE /* EmailStackViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */; };
 		14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */; };
+		14567EA029E00AF6000B75EE /* SignUpIDModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
 		14793FA629D8046E0048D5DD /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14793FA529D8046E0048D5DD /* ColorAssets.xcassets */; };
 		14793FA929D831230048D5DD /* ExUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14793FA829D831230048D5DD /* ExUIColor.swift */; };
@@ -65,6 +66,7 @@
 		14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellViewModel.swift; sourceTree = "<group>"; };
 		14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellModel.swift; sourceTree = "<group>"; };
 		14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedStackViewCellViewModel.swift; sourceTree = "<group>"; };
+		14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDModel.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
 		14793FA529D8046E0048D5DD /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
 		14793FA829D831230048D5DD /* ExUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExUIColor.swift; sourceTree = "<group>"; };
@@ -234,6 +236,7 @@
 				14DD371A29DB2C2E00D6A715 /* VerifiedStackViewCell */,
 				147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */,
 				14DD371029DB0EE700D6A715 /* SignUpIDViewModel.swift */,
+				14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */,
 			);
 			path = SignUpIDViewController;
 			sourceTree = "<group>";
@@ -374,6 +377,7 @@
 				14DD372429DB318900D6A715 /* SignUpPasswordViewModel.swift in Sources */,
 				14DD370F29DB0D5B00D6A715 /* EmailStackViewCell.swift in Sources */,
 				14793FBE29D83DA60048D5DD /* ExUIView.swift in Sources */,
+				14567EA029E00AF6000B75EE /* SignUpIDModel.swift in Sources */,
 				141A781829D7ED46006731F7 /* AppDelegate.swift in Sources */,
 				142DBEDF29DC4DCE00017603 /* MainTabBarController.swift in Sources */,
 				14DD372229DB30EC00D6A715 /* PasswordToCheckTextFieldCell.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		142DBEE129DC4FC300017603 /* MainTabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */; };
 		14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */; };
 		14567E9C29DFE824000B75EE /* EmailStackViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */; };
+		14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
 		14793FA629D8046E0048D5DD /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14793FA529D8046E0048D5DD /* ColorAssets.xcassets */; };
 		14793FA929D831230048D5DD /* ExUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14793FA829D831230048D5DD /* ExUIColor.swift */; };
@@ -63,6 +64,7 @@
 		142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewModel.swift; sourceTree = "<group>"; };
 		14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellViewModel.swift; sourceTree = "<group>"; };
 		14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellModel.swift; sourceTree = "<group>"; };
+		14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedStackViewCellViewModel.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
 		14793FA529D8046E0048D5DD /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
 		14793FA829D831230048D5DD /* ExUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExUIColor.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				14DD371229DB1DFB00D6A715 /* VerifiedStackViewCell.swift */,
+				14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */,
 			);
 			path = VerifiedStackViewCell;
 			sourceTree = "<group>";
@@ -356,6 +359,7 @@
 				14567E9C29DFE824000B75EE /* EmailStackViewCellModel.swift in Sources */,
 				147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */,
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
+				14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */,
 				142DBEDA29DC2EEB00017603 /* SignInViewModel.swift in Sources */,
 				14793FA929D831230048D5DD /* ExUIColor.swift in Sources */,
 				141A783629D7F1E5006731F7 /* SignInViewController.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14066BAF29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14066BAE29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift */; };
+		14066BB129E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14066BB029E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift */; };
 		141A781829D7ED46006731F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781729D7ED46006731F7 /* AppDelegate.swift */; };
 		141A781A29D7ED46006731F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781929D7ED46006731F7 /* SceneDelegate.swift */; };
 		141A782129D7ED46006731F7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 141A782029D7ED46006731F7 /* Assets.xcassets */; };
@@ -48,6 +50,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		14066BAE29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordTextFieldCellViewModel.swift; sourceTree = "<group>"; };
+		14066BB029E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordToCheckTextFieldCellViewModel.swift; sourceTree = "<group>"; };
 		141A781429D7ED46006731F7 /* WanF-Project.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WanF-Project.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		141A781729D7ED46006731F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		141A781929D7ED46006731F7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -185,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				14DD371F29DB301400D6A715 /* PasswordTextFieldCell.swift */,
+				14066BAE29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift */,
 			);
 			path = PasswordTextFieldCell;
 			sourceTree = "<group>";
@@ -193,6 +198,7 @@
 			isa = PBXGroup;
 			children = (
 				14DD372129DB30EC00D6A715 /* PasswordToCheckTextFieldCell.swift */,
+				14066BB029E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift */,
 			);
 			path = PasswordToCheckTextFieldCell;
 			sourceTree = "<group>";
@@ -367,6 +373,7 @@
 				14793FA929D831230048D5DD /* ExUIColor.swift in Sources */,
 				141A783629D7F1E5006731F7 /* SignInViewController.swift in Sources */,
 				142DBED229DC223A00017603 /* EmailTextFieldViewModel.swift in Sources */,
+				14066BAF29E1431300AFB2D2 /* PasswordTextFieldCellViewModel.swift in Sources */,
 				142DBED729DC2D2C00017603 /* PasswordTextFieldViewModel.swift in Sources */,
 				142DBED529DC2B0200017603 /* PasswordTextField.swift in Sources */,
 				142DBEE129DC4FC300017603 /* MainTabBarViewModel.swift in Sources */,
@@ -375,6 +382,7 @@
 				14DD371329DB1DFB00D6A715 /* VerifiedStackViewCell.swift in Sources */,
 				14DD372029DB301400D6A715 /* PasswordTextFieldCell.swift in Sources */,
 				14DD372429DB318900D6A715 /* SignUpPasswordViewModel.swift in Sources */,
+				14066BB129E1455F00AFB2D2 /* PasswordToCheckTextFieldCellViewModel.swift in Sources */,
 				14DD370F29DB0D5B00D6A715 /* EmailStackViewCell.swift in Sources */,
 				14793FBE29D83DA60048D5DD /* ExUIView.swift in Sources */,
 				14567EA029E00AF6000B75EE /* SignUpIDModel.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		142DBEDC29DC3D1100017603 /* SignInModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEDB29DC3D1100017603 /* SignInModel.swift */; };
 		142DBEDF29DC4DCE00017603 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEDE29DC4DCE00017603 /* MainTabBarController.swift */; };
 		142DBEE129DC4FC300017603 /* MainTabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */; };
+		14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
 		14793FA629D8046E0048D5DD /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14793FA529D8046E0048D5DD /* ColorAssets.xcassets */; };
 		14793FA929D831230048D5DD /* ExUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14793FA829D831230048D5DD /* ExUIColor.swift */; };
@@ -59,6 +60,7 @@
 		142DBEDB29DC3D1100017603 /* SignInModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInModel.swift; sourceTree = "<group>"; };
 		142DBEDE29DC4DCE00017603 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewModel.swift; sourceTree = "<group>"; };
+		14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellViewModel.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
 		14793FA529D8046E0048D5DD /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
 		14793FA829D831230048D5DD /* ExUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExUIColor.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 			isa = PBXGroup;
 			children = (
 				14DD370E29DB0D5B00D6A715 /* EmailStackViewCell.swift */,
+				14567E9929DFDD43000B75EE /* EmailStackViewCellViewModel.swift */,
 			);
 			path = EmailStackViewCell;
 			sourceTree = "<group>";
@@ -346,6 +349,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14793FBC29D837480048D5DD /* ExUIFont.swift in Sources */,
+				14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */,
 				147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */,
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
 				142DBEDA29DC2EEB00017603 /* SignInViewModel.swift in Sources */,

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCell.swift
@@ -13,6 +13,9 @@ import RxCocoa
 
 class EmailStackViewCell: UITableViewCell {
     
+    //MARK: - Properties
+    let disposeBag = DisposeBag()
+    
     //MARK: - View
     private lazy var emailStackView: UIStackView = {
         var stackView = UIStackView()
@@ -75,6 +78,13 @@ class EmailStackViewCell: UITableViewCell {
         
         configureView()
         layout()
+    }
+    
+    //MARK: - Function
+    func bind(_ viewModel: EmailStackViewCellViewModel) {
+        idTextField.rx.text
+            .bind(to: viewModel.inputedIDText)
+            .disposed(by: disposeBag)
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCell.swift
@@ -62,12 +62,7 @@ class EmailStackViewCell: UITableViewCell {
         configuration.baseBackgroundColor = .wanfMint
         configuration.attributedTitle = attributedString
         
-        let action = UIAction { _ in
-            print("Verify Email Address")
-        }
-        
         button.configuration = configuration
-        button.addAction(action, for: .touchUpInside)
         
         return button
     }()
@@ -82,9 +77,16 @@ class EmailStackViewCell: UITableViewCell {
     
     //MARK: - Function
     func bind(_ viewModel: EmailStackViewCellViewModel) {
+        
+        // View -> ViewModel
         idTextField.rx.text
             .bind(to: viewModel.inputedIDText)
             .disposed(by: disposeBag)
+        
+        verifiedButton.rx.tap
+            .bind(to: viewModel.sendEmailButtonTapped)
+            .disposed(by: disposeBag)
+        
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellModel.swift
@@ -1,0 +1,34 @@
+//
+//  EmailStackViewCellModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/04/07.
+//
+
+import Foundation
+
+import RxSwift
+
+// TODO: - 서버 연결 시 재구현
+struct EmailStackViewCellModel {
+    
+    func sendEmail(_ email: String) -> Single<Bool>  {
+        return Observable
+            .just(true)
+            .asSingle()
+    }
+    
+    func getEmailValue(_ result: Bool) -> Bool? {
+        if !result {
+            return nil
+        }
+        return true
+    }
+    
+    func getEmailError(_ result: Bool) -> Bool? {
+        if result {
+            return nil
+        }
+        return true
+    }
+}

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
@@ -25,7 +25,7 @@ struct EmailStackViewCellViewModel {
         //이메일
         let ID = inputedIDText
             .compactMap { $0 }
-        let emailAddress = Observable.just("@")
+        let emailAddress = Observable.just("@office.skhu.ac.kr")
         
         let emailText = Observable
             .combineLatest(ID, emailAddress) { ID,  address in

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
@@ -18,6 +18,7 @@ struct EmailStackViewCellViewModel {
     
     // ViewModel -> View
     let shouldLoadGuidance: Observable<Bool>
+    let shouldPresentAlertForError: Signal<AlertInfo>
     
     init(_ model: EmailStackViewCellModel = EmailStackViewCellModel()) {
         
@@ -45,7 +46,13 @@ struct EmailStackViewCellViewModel {
         let emailError = sendEmailResult
             .compactMap(model.getEmailError)
         
-        // TODO: - 이미 생성된 이메일 오류 메세지 표시하기
+        let alertInfo = emailError
+            .map { _ in
+                return (title: "이미 존재하는 이메일입니다", message: "")
+            }
+        
+        shouldPresentAlertForError = alertInfo
+            .asSignal(onErrorSignalWith: .empty())
         
     }
     

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
@@ -14,9 +14,14 @@ struct EmailStackViewCellViewModel {
     
     // View -> ViewModel
     let inputedIDText = PublishRelay<String?>()
+    let sendEmailButtonTapped = PublishRelay<Void>()
     
-    init() {
+    // ViewModel -> View
+    let shouldLoadGuidance: Observable<Bool>
+    
+    init(_ model: EmailStackViewCellModel = EmailStackViewCellModel()) {
         
+        //이메일
         let ID = inputedIDText
             .compactMap { $0 }
         let emailAddress = Observable.just("@")
@@ -25,6 +30,23 @@ struct EmailStackViewCellViewModel {
             .combineLatest(ID, emailAddress) { ID,  address in
                 ID + address
             }
+        
+        //전송 버튼
+        let sendEmailResult = sendEmailButtonTapped
+            .withLatestFrom(emailText)
+            .flatMapLatest(model.sendEmail)
+            .share()
+        
+        let emailValue = sendEmailResult
+            .compactMap(model.getEmailValue)
+        
+        shouldLoadGuidance = emailValue
+        
+        let emailError = sendEmailResult
+            .compactMap(model.getEmailError)
+        
+        // TODO: - 이미 생성된 이메일 오류 메세지 표시하기
+        
     }
     
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/EmailStackViewCell/EmailStackViewCellViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  EmailStackViewCellViewModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/04/07.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+struct EmailStackViewCellViewModel {
+    
+    // View -> ViewModel
+    let inputedIDText = PublishRelay<String?>()
+    
+    init() {
+        
+        let ID = inputedIDText
+            .compactMap { $0 }
+        let emailAddress = Observable.just("@")
+        
+        let emailText = Observable
+            .combineLatest(ID, emailAddress) { ID,  address in
+                ID + address
+            }
+    }
+    
+}

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDModel.swift
@@ -1,0 +1,35 @@
+//
+//  VerifiedStackViewCellModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/04/07.
+//
+
+import Foundation
+
+import RxSwift
+
+// TODO: - 서버 연결 시 재구현
+struct SignUpIDModel {
+    
+    func checkVerificationCode(_ code: String) -> Single<Bool> {
+        return Observable
+            .just(true)
+            .asSingle()
+    }
+    
+    func getVerificationValue(_ result: Bool) -> Bool? {
+        if !result {
+            return nil
+        }
+        return true
+    }
+    
+    func getVerificationError(_ result: Bool) -> Bool? {
+        if result {
+            return nil
+        }
+        return false
+    }
+    
+}

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -69,7 +69,7 @@ class SignUpIDViewController: UIViewController {
             .disposed(by: disposebag)
         
         // ViewModel -> View
-        viewModel.presentAlertForError
+        viewModel.presentAlertForEmailError
             .emit(to: self.rx.presentAlertForError)
             .disposed(by: disposebag)
         

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -60,11 +60,22 @@ class SignUpIDViewController: UIViewController {
     func bind(_ viewModel: SignUpIDViewModel) {
         
         // View -> ViewModel
+        nextBarItem.rx.tap
+            .bind(to: viewModel.nextButtonTapped)
+            .disposed(by: disposebag)
         
         // ViewModel -> View
-        
         viewModel.showGuidance
             .emit(to: self.rx.showGuidance)
+            .disposed(by: disposebag)
+        
+        viewModel.pushToMainTabBar
+            .drive(onNext: { viewModel in
+                let mainTabBarVC = MainTabBarController()
+                mainTabBarVC.bind(viewModel)
+                
+                self.present(mainTabBarVC, animated: true)
+            })
             .disposed(by: disposebag)
         
         viewModel.cellData
@@ -81,6 +92,7 @@ class SignUpIDViewController: UIViewController {
                     guard let cell = tv.dequeueReusableCell(withIdentifier: "VerifiedStackViewCell", for: IndexPath(row: row, section: 0)) as? VerifiedStackViewCell else { return UITableViewCell() }
                     
                     cell.selectionStyle = .none
+                    cell.bind(viewModel.verifiedStackViewCellViewModel)
                     
                     return cell
                 case 2:

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -73,7 +73,7 @@ class SignUpIDViewController: UIViewController {
             .emit(to: self.rx.showGuidance)
             .disposed(by: disposebag)
         
-        viewModel.pushToMainTabBar
+        viewModel.pushToSignUpPassword
             .drive(onNext: { viewModel in
                 let signUpPasswordVC = SignUpPasswordViewController()
                 signUpPasswordVC.bind(viewModel)

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -64,6 +64,10 @@ class SignUpIDViewController: UIViewController {
             .bind(to: viewModel.nextButtonTapped)
             .disposed(by: disposebag)
         
+        preBarItem.rx.tap
+            .bind(to: viewModel.preButtonTapped)
+            .disposed(by: disposebag)
+        
         // ViewModel -> View
         viewModel.showGuidance
             .emit(to: self.rx.showGuidance)
@@ -75,6 +79,12 @@ class SignUpIDViewController: UIViewController {
                 signUpPasswordVC.bind(viewModel)
                 
                 self.navigationController?.pushViewController(signUpPasswordVC, animated: true)
+            })
+            .disposed(by: disposebag)
+        
+        viewModel.popToSignIn
+            .drive(onNext: {
+                self.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposebag)
         

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -73,6 +73,10 @@ class SignUpIDViewController: UIViewController {
             .emit(to: self.rx.presentAlertForError)
             .disposed(by: disposebag)
         
+        viewModel.presentAlertForVerificationError
+            .emit(to: self.rx.presentAlertForError)
+            .disposed(by: disposebag)
+        
         viewModel.showGuidance
             .emit(to: self.rx.showGuidance)
             .disposed(by: disposebag)

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -71,10 +71,10 @@ class SignUpIDViewController: UIViewController {
         
         viewModel.pushToMainTabBar
             .drive(onNext: { viewModel in
-                let mainTabBarVC = MainTabBarController()
-                mainTabBarVC.bind(viewModel)
+                let signUpPasswordVC = SignUpPasswordViewController()
+                signUpPasswordVC.bind(viewModel)
                 
-                self.present(mainTabBarVC, animated: true)
+                self.navigationController?.pushViewController(signUpPasswordVC, animated: true)
             })
             .disposed(by: disposebag)
         

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -69,6 +69,10 @@ class SignUpIDViewController: UIViewController {
             .disposed(by: disposebag)
         
         // ViewModel -> View
+        viewModel.presentAlertForError
+            .emit(to: self.rx.presentAlertForError)
+            .disposed(by: disposebag)
+        
         viewModel.showGuidance
             .emit(to: self.rx.showGuidance)
             .disposed(by: disposebag)
@@ -154,11 +158,28 @@ private extension SignUpIDViewController {
     
 }
 
+typealias AlertInfo = (title: String, message: String)
+
 extension Reactive where Base: SignUpIDViewController {
     var showGuidance: Binder<Bool> {
         return Binder(base) { base, isShown in
             guard let cell = base.tableView.cellForRow(at: IndexPath(row: 2, section: 0)) else { return }
             cell.isHidden = !isShown
+        }
+    }
+    
+    var presentAlertForError: Binder<AlertInfo> {
+        return Binder(base) { base, alertInfo in
+            let alertVC = UIAlertController(
+                title: alertInfo.title,
+                message: alertInfo.message,
+                preferredStyle: .alert
+            )
+            let action = UIAlertAction(title: "확인", style: .default)
+            
+            alertVC.addAction(action)
+            
+            base.present(alertVC, animated: true)
         }
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewController.swift
@@ -25,7 +25,7 @@ class SignUpIDViewController: UIViewController {
         return item
     }()
     
-    private lazy var tableView: UITableView = {
+    lazy var tableView: UITableView = {
         var tableView = UITableView()
         
         tableView.backgroundColor = .wanfBackground
@@ -58,6 +58,15 @@ class SignUpIDViewController: UIViewController {
     
     //MARK: - Function
     func bind(_ viewModel: SignUpIDViewModel) {
+        
+        // View -> ViewModel
+        
+        // ViewModel -> View
+        
+        viewModel.showGuidance
+            .emit(to: self.rx.showGuidance)
+            .disposed(by: disposebag)
+        
         viewModel.cellData
             .drive(tableView.rx.items) { tv, row, element in
                 switch row {
@@ -65,6 +74,7 @@ class SignUpIDViewController: UIViewController {
                     guard let cell = tv.dequeueReusableCell(withIdentifier: "EmailStackViewCell", for: IndexPath(row: row, section: 0)) as? EmailStackViewCell else { return UITableViewCell() }
                     
                     cell.selectionStyle = .none
+                    cell.bind(viewModel.emailStackViewCellViewModel)
                     
                     return cell
                 case 1:
@@ -80,13 +90,14 @@ class SignUpIDViewController: UIViewController {
                         NSAttributedString.Key.font : UIFont.wanfFont(ofSize: 15, weight: .regular),
                         NSAttributedString.Key.foregroundColor : UIColor.orange
                     ]
-                    let attributedText = NSAttributedString(string: "인증번호 안내 문구",attributes: attributes)
+                    let attributedText = NSAttributedString(string: "인증번호 유효시간은 30분입니다.",attributes: attributes)
                     
                     var configuration = UIListContentConfiguration.cell()
                     configuration.attributedText = attributedText
                     
                     cell.contentConfiguration = configuration
                     cell.selectionStyle = .none
+                    cell.isHidden = true
                     
                     return cell
                 default:
@@ -119,4 +130,13 @@ private extension SignUpIDViewController {
         }
     }
     
+}
+
+extension Reactive where Base: SignUpIDViewController {
+    var showGuidance: Binder<Bool> {
+        return Binder(base) { base, isShown in
+            guard let cell = base.tableView.cellForRow(at: IndexPath(row: 2, section: 0)) else { return }
+            cell.isHidden = !isShown
+        }
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -17,12 +17,14 @@ struct SignUpIDViewModel {
     
     // View -> ViewModel
     let nextButtonTapped = PublishRelay<Void>()
+    let preButtonTapped = PublishRelay<Void>()
     
     // ViewModel -> View
     let cellData: Driver<[String]>
     
     let showGuidance: Signal<Bool>
     let pushToMainTabBar: Driver<SignUpPasswordViewModel>
+    let popToSignIn: Driver<Void>
     
     init(_ model: SignUpIDModel = SignUpIDModel()) {
         
@@ -57,5 +59,9 @@ struct SignUpIDViewModel {
             .compactMap(model.getVerificationError)
         
         // TODO: - 인증번호가 일치하지 않을 시 Alert 메세지 전달
+        
+        //이전 버튼
+        popToSignIn = preButtonTapped
+            .asDriver(onErrorDriveWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -25,7 +25,7 @@ struct SignUpIDViewModel {
     let showGuidance: Signal<Bool>
     let pushToSignUpPassword: Driver<SignUpPasswordViewModel>
     let popToSignIn: Driver<Void>
-    let presentAlertForError: Signal<AlertInfo>
+    let presentAlertForEmailError: Signal<AlertInfo>
     
     init(_ model: SignUpIDModel = SignUpIDModel()) {
         
@@ -63,12 +63,13 @@ struct SignUpIDViewModel {
         
         // TODO: - 인증번호가 일치하지 않을 시 Alert 메세지 전달
         
+        
         //이전 버튼
         popToSignIn = preButtonTapped
             .asDriver(onErrorDriveWith: .empty())
         
         //이메일 중복 오류 Alert
-        presentAlertForError = emailStackViewCellViewModel.shouldPresentAlertForError
+        presentAlertForEmailError = emailStackViewCellViewModel.shouldPresentAlertForError
             .asSignal(onErrorSignalWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -13,15 +13,19 @@ import RxCocoa
 struct SignUpIDViewModel {
     
     let emailStackViewCellViewModel = EmailStackViewCellViewModel()
+    let verifiedStackViewCellViewModel = VerifiedStackViewCellViewModel()
     
     // View -> ViewModel
+    let nextButtonTapped = PublishRelay<Void>()
     
     // ViewModel -> View
     let cellData: Driver<[String]>
     
     let showGuidance: Signal<Bool>
+    let pushToMainTabBar: Driver<MainTabBarViewModel>
     
-    init() {
+    init(_ model: SignUpIDModel = SignUpIDModel()) {
+        
         self.cellData = Observable
             .just([
                 "EmailStackViewCell",
@@ -32,5 +36,26 @@ struct SignUpIDViewModel {
         
         showGuidance = emailStackViewCellViewModel.shouldLoadGuidance
             .asSignal(onErrorJustReturn: false)
+        
+        //다음 버튼
+        let verificationCode = verifiedStackViewCellViewModel.inputedVerificationCode
+            .compactMap { $0 }
+        
+        let verificationResult = nextButtonTapped
+            .withLatestFrom(verificationCode)
+            .flatMapLatest(model.checkVerificationCode)
+            .share()
+        
+        let verificationValue = verificationResult
+            .compactMap(model.getVerificationValue)
+        
+        pushToMainTabBar = verificationValue
+            .map { _ in MainTabBarViewModel() }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        let verificationError = verificationResult
+            .compactMap(model.getVerificationError)
+        
+        // TODO: - 인증번호가 일치하지 않을 시 Alert 메세지 전달
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -11,6 +11,9 @@ import RxSwift
 import RxCocoa
 
 struct SignUpIDViewModel {
+    
+    let emailStackViewCellViewModel = EmailStackViewCellViewModel()
+    
     let cellData: Driver<[String]>
     
     init() {

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -22,7 +22,7 @@ struct SignUpIDViewModel {
     let cellData: Driver<[String]>
     
     let showGuidance: Signal<Bool>
-    let pushToMainTabBar: Driver<MainTabBarViewModel>
+    let pushToMainTabBar: Driver<SignUpPasswordViewModel>
     
     init(_ model: SignUpIDModel = SignUpIDModel()) {
         
@@ -50,7 +50,7 @@ struct SignUpIDViewModel {
             .compactMap(model.getVerificationValue)
         
         pushToMainTabBar = verificationValue
-            .map { _ in MainTabBarViewModel() }
+            .map { _ in SignUpPasswordViewModel() }
             .asDriver(onErrorDriveWith: .empty())
         
         let verificationError = verificationResult

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -23,7 +23,7 @@ struct SignUpIDViewModel {
     let cellData: Driver<[String]>
     
     let showGuidance: Signal<Bool>
-    let pushToMainTabBar: Driver<SignUpPasswordViewModel>
+    let pushToSignUpPassword: Driver<SignUpPasswordViewModel>
     let popToSignIn: Driver<Void>
     
     init(_ model: SignUpIDModel = SignUpIDModel()) {
@@ -51,7 +51,7 @@ struct SignUpIDViewModel {
         let verificationValue = verificationResult
             .compactMap(model.getVerificationValue)
         
-        pushToMainTabBar = verificationValue
+        pushToSignUpPassword = verificationValue
             .map { _ in SignUpPasswordViewModel() }
             .asDriver(onErrorDriveWith: .empty())
         

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -25,6 +25,7 @@ struct SignUpIDViewModel {
     let showGuidance: Signal<Bool>
     let pushToSignUpPassword: Driver<SignUpPasswordViewModel>
     let popToSignIn: Driver<Void>
+    let presentAlertForError: Signal<AlertInfo>
     
     init(_ model: SignUpIDModel = SignUpIDModel()) {
         
@@ -65,5 +66,9 @@ struct SignUpIDViewModel {
         //이전 버튼
         popToSignIn = preButtonTapped
             .asDriver(onErrorDriveWith: .empty())
+        
+        //이메일 중복 오류 Alert
+        presentAlertForError = emailStackViewCellViewModel.shouldPresentAlertForError
+            .asSignal(onErrorSignalWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -14,7 +14,12 @@ struct SignUpIDViewModel {
     
     let emailStackViewCellViewModel = EmailStackViewCellViewModel()
     
+    // View -> ViewModel
+    
+    // ViewModel -> View
     let cellData: Driver<[String]>
+    
+    let showGuidance: Signal<Bool>
     
     init() {
         self.cellData = Observable
@@ -24,5 +29,8 @@ struct SignUpIDViewModel {
                 "AlertMessageCell"
             ])
             .asDriver(onErrorJustReturn: [])
+        
+        showGuidance = emailStackViewCellViewModel.shouldLoadGuidance
+            .asSignal(onErrorJustReturn: false)
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -26,6 +26,7 @@ struct SignUpIDViewModel {
     let pushToSignUpPassword: Driver<SignUpPasswordViewModel>
     let popToSignIn: Driver<Void>
     let presentAlertForEmailError: Signal<AlertInfo>
+    let presentAlertForVerificationError: Signal<AlertInfo>
     
     init(_ model: SignUpIDModel = SignUpIDModel()) {
         
@@ -61,8 +62,11 @@ struct SignUpIDViewModel {
         let verificationError = verificationResult
             .compactMap(model.getVerificationError)
         
-        // TODO: - 인증번호가 일치하지 않을 시 Alert 메세지 전달
-        
+        presentAlertForVerificationError = verificationError
+            .map { _ in
+                return (title: "인증번호가 일치하지 않습니다", message: "")
+            }
+            .asSignal(onErrorSignalWith: .empty())
         
         //이전 버튼
         popToSignIn = preButtonTapped

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -52,7 +52,9 @@ struct SignUpIDViewModel {
             .compactMap(model.getVerificationValue)
         
         pushToSignUpPassword = verificationValue
-            .map { _ in SignUpPasswordViewModel() }
+            .withLatestFrom(emailStackViewCellViewModel.inputedIDText)
+            .compactMap { $0 }
+            .map { email in SignUpPasswordViewModel(email: email) }
             .asDriver(onErrorDriveWith: .empty())
         
         let verificationError = verificationResult

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCell.swift
@@ -56,6 +56,18 @@ class VerifiedStackViewCell: UITableViewCell {
         configureView()
         layout()
     }
+    
+    //MARK: - Function
+    func bind(_ viewModel: VerifiedStackViewCellViewModel) {
+        
+        // View -> ViewModel
+        verificationCodeTextField.rx.text
+            .bind(to: viewModel.inputedVerifiedCode)
+            .disposed(by: DisposeBag())
+        
+        // ViewModel -> View
+        
+    }
 }
 
 //MARK: - Configure

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCell.swift
@@ -62,7 +62,7 @@ class VerifiedStackViewCell: UITableViewCell {
         
         // View -> ViewModel
         verificationCodeTextField.rx.text
-            .bind(to: viewModel.inputedVerifiedCode)
+            .bind(to: viewModel.inputedVerificationCode)
             .disposed(by: DisposeBag())
         
         // ViewModel -> View

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCellViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  VerifiedStackViewCellViewModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/04/07.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+class VerifiedStackViewCellViewModel {
+    
+    // View -> ViewModel
+    let inputedVerifiedCode = PublishRelay<String?>()
+    
+    // ViewModel -> View
+    
+    init() {
+        
+    }
+}

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCellViewModel.swift
@@ -13,7 +13,7 @@ import RxCocoa
 class VerifiedStackViewCellViewModel {
     
     // View -> ViewModel
-    let inputedVerifiedCode = PublishRelay<String?>()
+    let inputedVerificationCode = PublishRelay<String?>()
     
     // ViewModel -> View
     

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/VerifiedStackViewCell/VerifiedStackViewCellViewModel.swift
@@ -17,7 +17,4 @@ class VerifiedStackViewCellViewModel {
     
     // ViewModel -> View
     
-    init() {
-        
-    }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordTextFieldCell/PasswordTextFieldCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordTextFieldCell/PasswordTextFieldCell.swift
@@ -23,6 +23,7 @@ class PasswordTextFieldCell: UITableViewCell {
         textField.font = .wanfFont(ofSize: 16, weight: .regular)
         textField.placeholder = "영문 • 숫자 조합으로 8자리 이상 작성하세요"
         textField.textAlignment = .center
+        textField.isSecureTextEntry = true
         textField.tintColor = .wanfMint
         textField.layer.borderColor = UIColor.wanfLightGray.cgColor
         textField.layer.borderWidth = 1.0

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordTextFieldCell/PasswordTextFieldCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordTextFieldCell/PasswordTextFieldCell.swift
@@ -13,6 +13,9 @@ import RxCocoa
 
 class PasswordTextFieldCell: UITableViewCell {
     
+    //MARK: - Propertise
+    let disposeBag = DisposeBag()
+    
     //MARK: - View
     private lazy var passwordTextField: UITextField = {
         var textField = UITextField()
@@ -33,6 +36,15 @@ class PasswordTextFieldCell: UITableViewCell {
         
         configureView()
         layout()
+    }
+    
+    //MARK: - Function
+    func bind(_ viewModel: PasswordTextFieldCellViewModel) {
+        
+        // View -> ViewModel
+        passwordTextField.rx.text
+            .bind(to: viewModel.inputedPasswordText)
+            .disposed(by: disposeBag )
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordTextFieldCell/PasswordTextFieldCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordTextFieldCell/PasswordTextFieldCellViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  PasswordTextFieldCellViewModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/04/08.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+struct PasswordTextFieldCellViewModel {
+    
+    // View -> ViewModel
+    let inputedPasswordText = PublishRelay<String?>()
+   
+}

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCell.swift
@@ -46,6 +46,10 @@ class  PasswordToCheckTextFieldCell: UITableViewCell {
             .bind(to: viewModel.inputedPasswordToCheckText)
             .disposed(by: disposeBag)
         
+        passwordToCheckTextField.rx.controlEvent(.editingChanged)
+            .bind(to: viewModel.passswordToCheckDidChange)
+            .disposed(by: disposeBag)
+
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCell.swift
@@ -23,6 +23,7 @@ class  PasswordToCheckTextFieldCell: UITableViewCell {
         textField.font = .wanfFont(ofSize: 16, weight: .regular)
         textField.placeholder = "비밀번호 확인"
         textField.textAlignment = .center
+        textField.isSecureTextEntry = true
         textField.tintColor = .wanfMint
         textField.layer.borderColor = UIColor.wanfLightGray.cgColor
         textField.layer.borderWidth = 1.0

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCell.swift
@@ -13,6 +13,9 @@ import RxCocoa
 
 class  PasswordToCheckTextFieldCell: UITableViewCell {
     
+    //MARK: - Propertise
+    let disposeBag = DisposeBag()
+    
     //MARK: - View
     private lazy var passwordToCheckTextField: UITextField = {
         var textField = UITextField()
@@ -33,6 +36,16 @@ class  PasswordToCheckTextFieldCell: UITableViewCell {
         
         configureView()
         layout()
+    }
+    
+    //MARK: - Function
+    func bind(_ viewModel: PasswordToCheckTextFieldCellViewModel) {
+        
+        // View -> ViewModel
+        passwordToCheckTextField.rx.text
+            .bind(to: viewModel.inputedPasswordToCheckText)
+            .disposed(by: disposeBag)
+        
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCellViewModel.swift
@@ -14,5 +14,6 @@ struct PasswordToCheckTextFieldCellViewModel {
     
     // View -> ViewModel
     let inputedPasswordToCheckText = PublishRelay<String?>()
+    let passswordToCheckDidChange = PublishRelay<Void>()
     
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/PasswordToCheckTextFieldCell/PasswordToCheckTextFieldCellViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  PasswordToCheckTextFieldCellViewModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/04/08.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+struct PasswordToCheckTextFieldCellViewModel {
+    
+    // View -> ViewModel
+    let inputedPasswordToCheckText = PublishRelay<String?>()
+    
+}

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordModel.swift
@@ -1,0 +1,34 @@
+//
+//  SignUpPasswordModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/04/08.
+//
+
+import Foundation
+
+import RxSwift
+
+// TODO: - 서버 연결 시 재구현
+struct SignUpPasswordModel {
+    
+    func signUp(_ signUpData: (String, String)) -> Single<Bool> {
+        return Observable
+            .just(true)
+            .asSingle()
+    }
+    
+    func getSignUpValue(_ result: Bool) -> Bool? {
+        if !result {
+            return nil
+        }
+        return true
+    }
+    
+    func getSignUpError(_ result: Bool) -> Bool? {
+        if result {
+            return nil
+        }
+        return false
+    }
+}

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
@@ -43,6 +43,7 @@ class SignUpPasswordViewController: UIViewController {
         var item = UIBarButtonItem()
         
         item.title = "완료"
+        item.isEnabled = false
         
         return item
     }()
@@ -66,6 +67,13 @@ class SignUpPasswordViewController: UIViewController {
         
         
         // ViewModel -> View
+        viewModel.enableDoneButton
+            .drive(onNext: {
+                self.doneBarItem.isEnabled = $0
+            })
+            .disposed(by: disposebag)
+        
+        
         viewModel.popToSignUpID
             .drive(onNext: {
                 self.navigationController?.popViewController(animated: true)

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
@@ -60,8 +60,18 @@ class SignUpPasswordViewController: UIViewController {
     func bind(_ viewModel: SignUpPasswordViewModel) {
         
         // View -> ViewModel
+        preBarItem.rx.tap
+            .bind(to: viewModel.preButtonTapped)
+            .disposed(by: disposebag)
+        
         
         // ViewModel -> View
+        viewModel.popToSignUpID
+            .drive(onNext: {
+                self.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposebag)
+        
         viewModel.showGuidance
             .emit(to: self.rx.showGuidance)
             .disposed(by: disposebag)

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
@@ -25,7 +25,7 @@ class SignUpPasswordViewController: UIViewController {
         return item
     }()
     
-    private lazy var tableView: UITableView = {
+    lazy var tableView: UITableView = {
         var tableView = UITableView()
         
         tableView.backgroundColor = .wanfBackground
@@ -58,18 +58,28 @@ class SignUpPasswordViewController: UIViewController {
     
     //MARK: - Function
     func bind(_ viewModel: SignUpPasswordViewModel) {
+        
+        // View -> ViewModel
+        
+        // ViewModel -> View
+        viewModel.showGuidance
+            .emit(to: self.rx.showGuidance)
+            .disposed(by: disposebag)
+        
         viewModel.cellData
             .drive(tableView.rx.items) { tv, row, element in
                 switch row {
                 case 0:
                     guard let cell = tv.dequeueReusableCell(withIdentifier: "PasswordTextFieldCell", for: IndexPath(row: row, section: 0)) as? PasswordTextFieldCell else { return UITableViewCell() }
                     
+                    cell.bind(viewModel.passwordTextFieldCellViewModel)
                     cell.selectionStyle = .none
                     
                     return cell
                 case 1:
                     guard let cell = tv.dequeueReusableCell(withIdentifier: "PasswordToCheckTextFieldCell", for: IndexPath(row: row, section: 0)) as? PasswordToCheckTextFieldCell else { return UITableViewCell() }
                     
+                    cell.bind(viewModel.passwordToCheckTextFieldCellViewModel)
                     cell.selectionStyle = .none
                     
                     return cell
@@ -80,12 +90,13 @@ class SignUpPasswordViewController: UIViewController {
                         NSAttributedString.Key.font : UIFont.wanfFont(ofSize: 15, weight: .regular),
                         NSAttributedString.Key.foregroundColor : UIColor.orange
                     ]
-                    let attributedText = NSAttributedString(string: "인증번호 안내 문구",attributes: attributes)
+                    let attributedText = NSAttributedString(string: "비밀번호가 일치하지 않습니다.",attributes: attributes)
                     
                     var configuration = UIListContentConfiguration.cell()
                     configuration.attributedText = attributedText
                     
                     cell.contentConfiguration = configuration
+                    cell.isHidden = true
                     cell.selectionStyle = .none
                     
                     return cell
@@ -116,6 +127,15 @@ private extension SignUpPasswordViewController {
         tableView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(20)
             make.horizontalEdges.bottom.equalToSuperview().inset(20)
+        }
+    }
+}
+
+extension Reactive where Base: SignUpPasswordViewController {
+    var showGuidance: Binder<Bool> {
+        return Binder(base) { base, isShown in
+            guard let cell = base.tableView.cellForRow(at: IndexPath(row: 2, section: 0 )) else { return }
+            cell.isHidden = !isShown
         }
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
@@ -65,6 +65,9 @@ class SignUpPasswordViewController: UIViewController {
             .bind(to: viewModel.preButtonTapped)
             .disposed(by: disposebag)
         
+        doneBarItem.rx.tap
+            .bind(to: viewModel.doneButtonTapped)
+            .disposed(by: disposebag)
         
         // ViewModel -> View
         viewModel.enableDoneButton
@@ -73,6 +76,14 @@ class SignUpPasswordViewController: UIViewController {
             })
             .disposed(by: disposebag)
         
+        viewModel.presentMainTabBar
+            .drive(onNext: { viewModel in
+                let mainTabBarVC = MainTabBarController()
+                mainTabBarVC.bind(viewModel)
+                
+                self.present(mainTabBarVC, animated: true)
+            })
+            .disposed(by: disposebag)
         
         viewModel.popToSignUpID
             .drive(onNext: {

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewController.swift
@@ -85,6 +85,10 @@ class SignUpPasswordViewController: UIViewController {
             })
             .disposed(by: disposebag)
         
+        viewModel.presentAlertForSignUpError
+            .emit(to: self.rx.presentAlertForError)
+            .disposed(by: disposebag)
+        
         viewModel.popToSignUpID
             .drive(onNext: {
                 self.navigationController?.popViewController(animated: true)
@@ -165,6 +169,21 @@ extension Reactive where Base: SignUpPasswordViewController {
         return Binder(base) { base, isShown in
             guard let cell = base.tableView.cellForRow(at: IndexPath(row: 2, section: 0 )) else { return }
             cell.isHidden = !isShown
+        }
+    }
+    
+    var presentAlertForError: Binder<AlertInfo> {
+        return Binder(base) { base, alertInfo in
+            let alertVC = UIAlertController(
+                title: alertInfo.title,
+                message: alertInfo.message,
+                preferredStyle: .alert
+            )
+            let action = UIAlertAction(title: "확인", style: .default)
+            
+            alertVC.addAction(action)
+            
+            base.present(alertVC, animated: true)
         }
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
@@ -17,10 +17,12 @@ struct SignUpPasswordViewModel {
     
     // View -> ViewModel
     let preButtonTapped = PublishRelay<Void>()
+    let doneButtonTapped = PublishRelay<Void>()
     
     // ViewModel -> View
     let cellData: Driver<[String]>
     let showGuidance: Signal<Bool>
+    let enableDoneButton: Driver<Bool>
     
     let popToSignUpID: Driver<Void>
     
@@ -53,6 +55,16 @@ struct SignUpPasswordViewModel {
                 return true
             }
             .asSignal(onErrorJustReturn: false)
+        
+        //완료 버튼 활성화
+        enableDoneButton = showGuidance
+            .map { isShownGuidance -> Bool in
+                if isShownGuidance {
+                    return false
+                }
+                return true
+            }
+            .asDriver(onErrorJustReturn: false)
         
         
         //이전 화면으로 전환

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
@@ -26,7 +26,7 @@ struct SignUpPasswordViewModel {
     
     let popToSignUpID: Driver<Void>
     
-    init() {
+    init(email: String, _ model: SignUpPasswordModel = SignUpPasswordModel()) {
         
         self.cellData = Observable
             .just([
@@ -66,6 +66,21 @@ struct SignUpPasswordViewModel {
             }
             .asDriver(onErrorJustReturn: false)
         
+        //완료 버튼
+        let signUpData = Observable
+            .combineLatest(Observable.just(email), password)
+
+        let signUpResult = doneButtonTapped
+            .withLatestFrom(signUpData)
+            .flatMap(model.signUp)
+            .share()
+        
+        let signUpValue = signUpResult
+            .compactMap { $0 }
+        
+        
+        let signUpError = signUpResult
+            .compactMap { $0 }
         
         //이전 화면으로 전환
         popToSignUpID = preButtonTapped

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
@@ -26,6 +26,7 @@ struct SignUpPasswordViewModel {
     
     let popToSignUpID: Driver<Void>
     let presentMainTabBar: Driver<MainTabBarViewModel>
+    let presentAlertForSignUpError: Signal<AlertInfo>
     
     init(email: String, _ model: SignUpPasswordModel = SignUpPasswordModel()) {
         
@@ -77,7 +78,7 @@ struct SignUpPasswordViewModel {
             .share()
         
         let signUpValue = signUpResult
-            .compactMap { $0 }
+            .compactMap(model.getSignUpValue)
         
         presentMainTabBar = signUpValue
             .map { _ in
@@ -86,7 +87,14 @@ struct SignUpPasswordViewModel {
             .asDriver(onErrorDriveWith: .empty())
         
         let signUpError = signUpResult
-            .compactMap { $0 }
+            .compactMap(model.getSignUpError)
+        
+        presentAlertForSignUpError = signUpError
+            .map { _ in
+                // TODO: - 오류 상태코드 별 메세지 지정
+                return (title: "회원가입 실패", message: "")
+            }
+            .asSignal(onErrorSignalWith: .empty())
         
         //이전 화면으로 전환
         popToSignUpID = preButtonTapped

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
@@ -11,9 +11,18 @@ import RxSwift
 import RxCocoa
 
 struct SignUpPasswordViewModel {
+    
+    let passwordTextFieldCellViewModel = PasswordTextFieldCellViewModel()
+    let passwordToCheckTextFieldCellViewModel = PasswordToCheckTextFieldCellViewModel()
+    
+    // View -> ViewModel
+    
+    // ViewModel -> View
     let cellData: Driver<[String]>
+    let showGuidance: Signal<Bool>
     
     init() {
+        
         self.cellData = Observable
             .just([
                 "EmailStackViewCell",
@@ -21,5 +30,26 @@ struct SignUpPasswordViewModel {
                 "AlertMessageCell"
             ])
             .asDriver(onErrorJustReturn: [])
+        
+        //비밀번호 일치 확인
+        let password = passwordTextFieldCellViewModel.inputedPasswordText
+            .compactMap { $0 }
+        let passwordToCheck = passwordToCheckTextFieldCellViewModel.inputedPasswordToCheckText
+            .compactMap { $0 }
+        
+        let combinedPassword = Observable
+            .combineLatest(password, passwordToCheck)
+        
+        showGuidance = passwordToCheckTextFieldCellViewModel.passswordToCheckDidChange
+            .asObservable()
+            .withLatestFrom(combinedPassword)
+            .map { (password, passwordToCheck) -> Bool in
+                if password == passwordToCheck {
+                    return false
+                }
+                return true
+            }
+            .asSignal(onErrorJustReturn: false)
+        
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
@@ -25,6 +25,7 @@ struct SignUpPasswordViewModel {
     let enableDoneButton: Driver<Bool>
     
     let popToSignUpID: Driver<Void>
+    let presentMainTabBar: Driver<MainTabBarViewModel>
     
     init(email: String, _ model: SignUpPasswordModel = SignUpPasswordModel()) {
         
@@ -78,6 +79,11 @@ struct SignUpPasswordViewModel {
         let signUpValue = signUpResult
             .compactMap { $0 }
         
+        presentMainTabBar = signUpValue
+            .map { _ in
+                return MainTabBarViewModel()
+            }
+            .asDriver(onErrorDriveWith: .empty())
         
         let signUpError = signUpResult
             .compactMap { $0 }

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpPasswordViewController/SignUpPasswordViewModel.swift
@@ -16,10 +16,13 @@ struct SignUpPasswordViewModel {
     let passwordToCheckTextFieldCellViewModel = PasswordToCheckTextFieldCellViewModel()
     
     // View -> ViewModel
+    let preButtonTapped = PublishRelay<Void>()
     
     // ViewModel -> View
     let cellData: Driver<[String]>
     let showGuidance: Signal<Bool>
+    
+    let popToSignUpID: Driver<Void>
     
     init() {
         
@@ -51,5 +54,9 @@ struct SignUpPasswordViewModel {
             }
             .asSignal(onErrorJustReturn: false)
         
+        
+        //이전 화면으로 전환
+        popToSignUpID = preButtonTapped
+            .asDriver(onErrorDriveWith: .empty())
     }
 }


### PR DESCRIPTION
# 👩‍💻구현 내용
회원가입 기능 구현
++ 회원가입 비밀번호 입력 암호화 UI 적용

- 학교 이메일 인증 화면:
- [x] 이메일 아이디 입력 받고 메일 주소와 조합
- [x] 전송 버튼: 인증번호 안내문구 표시 • 전송 오류 시 Alert 표시
- [x] 인증번호 입력 받기
- [x] 다음 버튼: 인증 번호 확인 성공 시 비밀번호 설정 화면 전환 • 오류 시 Alert 표시
- [x] 이전 버튼: 로그인 화면으로 화면 전환

- 비밀번호 설정 화면:
- [x] 비밀번호와 비밀번호 확인 입력받기
- [x] 비밀번호 확인 입력값이 달라질 때마다 일치여부 확인 후 안내문구 표시
- [x] 완료 버튼: 비밀번호 일치 시 활성화 • 이메일과 비밀번호 전송-> 성공 시 MainTapBar 화면 전환/ 오류 Alert 표시
- [x] 이전 버튼: SignUp ID 화면 전환

<br>

### ❗️이슈
- 서버 연결 시 각 화면 오류 Alert 메세지 구체화하기
- 메일 주소 PropertyList로 저장해 사용하기

<br>
<br>

| 학교 이메일 인증 화면 | 비밀번호 설정 화면 |
| ----- | ----- |
| <img src = "https://user-images.githubusercontent.com/65601189/230752140-a1acaddb-db85-4c7b-8346-bbf554192d71.gif" width = 350 height = 750> | <img src = "https://user-images.githubusercontent.com/65601189/230752155-719fd766-6189-493e-82c7-0ef740f8ae94.gif" width = 350 height = 750> |

| 인증번호 오류 | 회원가입 실패 오류 | 이메일 중복 오류 |
| ----- | ----- | ----- |
| <img src = "https://user-images.githubusercontent.com/65601189/230752355-432b3a27-29ee-4335-88c0-a8bb81194323.png" width = 350 height = 600> | <img src = "https://user-images.githubusercontent.com/65601189/230752367-c9ec864f-6f93-48fe-ac95-dfa91141586c.png" width = 350 height = 600> | <img src = "https://user-images.githubusercontent.com/65601189/230752378-548c14e2-5251-4ef0-8749-da9bb881d998.png" width = 350 height = 600> |


<br>
#9 

