### PR TITLE
SignIn 화면: 서버 연결 구현

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		14567EA029E00AF6000B75EE /* SignUpIDModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */; };
 		1466FA222A0A482B00910C30 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA212A0A482B00910C30 /* UserDefaultsManager.swift */; };
 		1466FA242A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */; };
+		1466FA1E2A0A412500910C30 /* SignInAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA1D2A0A412500910C30 /* SignInAPI.swift */; };
+		1466FA202A0A428D00910C30 /* SignInNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA1F2A0A428D00910C30 /* SignInNetwork.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
 		14793FA629D8046E0048D5DD /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14793FA529D8046E0048D5DD /* ColorAssets.xcassets */; };
 		14793FA929D831230048D5DD /* ExUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14793FA829D831230048D5DD /* ExUIColor.swift */; };
@@ -145,6 +147,8 @@
 		14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDModel.swift; sourceTree = "<group>"; };
 		1466FA212A0A482B00910C30 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAuthorizationWrapper.swift; sourceTree = "<group>"; };
+		1466FA1D2A0A412500910C30 /* SignInAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAPI.swift; sourceTree = "<group>"; };
+		1466FA1F2A0A428D00910C30 /* SignInNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInNetwork.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
 		14793FA529D8046E0048D5DD /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
 		14793FA829D831230048D5DD /* ExUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExUIColor.swift; sourceTree = "<group>"; };
@@ -340,6 +344,8 @@
 				1466FA1C2A0A100400910C30 /* SignUpNetwork */,
 				144D30CC2A06259700640CCD /* WanfAPI.swift */,
 				144D30D42A06295100640CCD /* WanfNetwork.swift */,
+				1466FA1D2A0A412500910C30 /* SignInAPI.swift */,
+				1466FA1F2A0A428D00910C30 /* SignInNetwork.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -733,6 +739,7 @@
 				14AC9B3729E27547009C37A5 /* ClassInfoViewController.swift in Sources */,
 				14793FA929D831230048D5DD /* ExUIColor.swift in Sources */,
 				141A783629D7F1E5006731F7 /* SignInViewController.swift in Sources */,
+				1466FA202A0A428D00910C30 /* SignInNetwork.swift in Sources */,
 				14BD19F229FBB9EF00B0E598 /* ProfileContentKeywordListCell.swift in Sources */,
 				142DBED229DC223A00017603 /* EmailTextFieldViewModel.swift in Sources */,
 				14E4C9E929EA564400E2CB62 /* LectureInfoViewModel.swift in Sources */,
@@ -773,6 +780,7 @@
 				14D7A90329E92F9B007850BE /* FriendsMatchWritingTopBarView.swift in Sources */,
 				144D30CD2A06259700640CCD /* WanfAPI.swift in Sources */,
 				14982C9129EEACD200D388BF /* FriendsMatchDetailModel.swift in Sources */,
+				1466FA1E2A0A412500910C30 /* SignInAPI.swift in Sources */,
 				14AC9B3929E27569009C37A5 /* ClassGroupViewController.swift in Sources */,
 				14E4C9E429EA530F00E2CB62 /* LectureInfoViewController.swift in Sources */,
 				14D7A90A29E936A3007850BE /* FriendsMatchWritingLectureInfoView.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		14567E9C29DFE824000B75EE /* EmailStackViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */; };
 		14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */; };
 		14567EA029E00AF6000B75EE /* SignUpIDModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */; };
+		1466FA222A0A482B00910C30 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA212A0A482B00910C30 /* UserDefaultsManager.swift */; };
+		1466FA242A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
 		14793FA629D8046E0048D5DD /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14793FA529D8046E0048D5DD /* ColorAssets.xcassets */; };
 		14793FA929D831230048D5DD /* ExUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14793FA829D831230048D5DD /* ExUIColor.swift */; };
@@ -141,6 +143,8 @@
 		14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellModel.swift; sourceTree = "<group>"; };
 		14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedStackViewCellViewModel.swift; sourceTree = "<group>"; };
 		14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDModel.swift; sourceTree = "<group>"; };
+		1466FA212A0A482B00910C30 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
+		1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAuthorizationWrapper.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
 		14793FA529D8046E0048D5DD /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
 		14793FA829D831230048D5DD /* ExUIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExUIColor.swift; sourceTree = "<group>"; };
@@ -359,6 +363,15 @@
 			path = SignUpNetwork;
 			sourceTree = "<group>";
 		};
+		1466FA252A0A4B6B00910C30 /* UserDefaultsManager */ = {
+			isa = PBXGroup;
+			children = (
+				1466FA212A0A482B00910C30 /* UserDefaultsManager.swift */,
+				1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */,
+			);
+			path = UserDefaultsManager;
+			sourceTree = "<group>";
+		};
 		14793FA729D82F1D0048D5DD /* Extension */ = {
 			isa = PBXGroup;
 			children = (
@@ -495,6 +508,7 @@
 		14D4C2DF29FD0AC6001ACBC6 /* Custom */ = {
 			isa = PBXGroup;
 			children = (
+				1466FA252A0A4B6B00910C30 /* UserDefaultsManager */,
 				14D4C2D829FCF427001ACBC6 /* LeadingAlignmentCollectionViewFlowLayout.swift */,
 				14D4C2DC29FD0407001ACBC6 /* DynamicHeightCollectionView.swift */,
 			);
@@ -754,6 +768,7 @@
 				144D30C72A06096000640CCD /* ProfileSingleSelectionListModel.swift in Sources */,
 				14D4C2E529FD4BF9001ACBC6 /* ProfileContentModel.swift in Sources */,
 				14D4C2D929FCF427001ACBC6 /* LeadingAlignmentCollectionViewFlowLayout.swift in Sources */,
+				1466FA222A0A482B00910C30 /* UserDefaultsManager.swift in Sources */,
 				14840E4929FE5C8C007BFB1A /* ProfileKeywordListViewController.swift in Sources */,
 				14D7A90329E92F9B007850BE /* FriendsMatchWritingTopBarView.swift in Sources */,
 				144D30CD2A06259700640CCD /* WanfAPI.swift in Sources */,
@@ -770,6 +785,7 @@
 				141A781A29D7ED46006731F7 /* SceneDelegate.swift in Sources */,
 				144D30C32A0606F000640CCD /* ProfileSingleSelectionListViewController.swift in Sources */,
 				14870BF129EBBD9400D9643E /* FriendsMatchWritingLectureInfoViewModel.swift in Sources */,
+				1466FA242A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift in Sources */,
 				14DD371E29DB2CBB00D6A715 /* SignUpPasswordViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WanF-Project/WanF-Project/Custom/UserDefaultsManager/UserDefaultsAuthorizationWrapper.swift
+++ b/WanF-Project/WanF-Project/Custom/UserDefaultsManager/UserDefaultsAuthorizationWrapper.swift
@@ -1,0 +1,27 @@
+//
+//  UserDefaultsAuthorizationWrapper.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/05/09.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefaultsAuthorizationWrapper {
+    
+    private let key: String
+    
+    init(_ key: String) {
+        self.key = key
+    }
+    
+    var wrappedValue: String? {
+        get {
+            return UserDefaults.standard.string(forKey: key)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+}

--- a/WanF-Project/WanF-Project/Custom/UserDefaultsManager/UserDefaultsManager.swift
+++ b/WanF-Project/WanF-Project/Custom/UserDefaultsManager/UserDefaultsManager.swift
@@ -1,0 +1,16 @@
+//
+//  UserDefaultsManager.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/05/09.
+//
+
+import Foundation
+
+struct UserDefaultsManager {
+    @UserDefaultsAuthorizationWrapper("AccessToken")
+    static var accessToken: String?
+    
+    @UserDefaultsAuthorizationWrapper("RefreshToken")
+    static var refreshToken: String?
+}

--- a/WanF-Project/WanF-Project/Network/SignInAPI.swift
+++ b/WanF-Project/WanF-Project/Network/SignInAPI.swift
@@ -1,0 +1,29 @@
+//
+//  SignInAPI.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/05/09.
+//
+
+import Foundation
+
+class SignInAPI: WanfAPI {
+    
+    //MARK: - Properties
+    let path = "/api/v1/auth/"
+    
+    init() {
+        super.init()
+    }
+    
+    //MARK: - Function
+    // 로그인
+    func signIn() -> URLComponents {
+        var components = URLComponents()
+        components.scheme = super.scheme
+        components.host  = super.host
+        components.path = self.path + "login"
+        
+        return components
+    }
+}

--- a/WanF-Project/WanF-Project/Network/SignInNetwork.swift
+++ b/WanF-Project/WanF-Project/Network/SignInNetwork.swift
@@ -1,0 +1,55 @@
+//
+//  SignInNetwork.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/05/09.
+//
+
+import Foundation
+
+import RxSwift
+
+class SignInNetwork: WanfNetwork {
+    
+    //MARK: - Properties
+    let api = SignInAPI()
+    
+    init() {
+        super.init()
+    }
+    
+    // 로그인
+    func signIn(email: String, password: String) -> Single<Result<Void, WanfError>> {
+        guard let url = api.signIn().url else {
+            return .just(.failure(.invalidURL))
+        }
+        
+        let body: Dictionary<String, String> = [
+            "email" : email,
+            "userPassword" : password
+        ]
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json;charset=UTF-8", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(body)
+        
+        return super.session.rx.response(request: request)
+            .map { response, data in
+                guard let accessToken = response.value(forHTTPHeaderField: "authorization"),
+                      let refreshToken = response.value(forHTTPHeaderField: "x-refresh-token")
+                else {
+                    return .failure(.invalidJSON)
+                }
+                
+                UserDefaultsManager.accessToken = accessToken
+                UserDefaultsManager.refreshToken = refreshToken
+                
+                return .success(Void())
+            }
+            .catch { error in
+                    .just(.failure(.networkError))
+            }
+            .asSingle()
+    }
+}

--- a/WanF-Project/WanF-Project/Presentation/SignInViewController/EmailTextField/EmailTextFieldViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignInViewController/EmailTextField/EmailTextFieldViewModel.swift
@@ -12,6 +12,14 @@ import RxCocoa
 
 struct EmailTextFieldViewModel {
     
+    // View -> ViewModel
     let emailData = PublishRelay<String?>()
     
+    // ViewModel -> ParentViewModel
+    let email: Observable<String>
+    
+    init() {
+        email = emailData
+            .compactMap { $0 }
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignInViewController/PasswordTextField/PasswordTextFieldViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignInViewController/PasswordTextField/PasswordTextFieldViewModel.swift
@@ -12,6 +12,14 @@ import RxCocoa
 
 struct PasswordTextFieldViewModel {
     
+    // View -> ViewModel
     let passwordData = PublishRelay<String?>()
     
+    // ViewModel -> ParentViewModel
+    let password: Observable<String>
+    
+    init() {
+        password = passwordData
+            .compactMap { $0 }
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignInViewController/SignInModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignInViewController/SignInModel.swift
@@ -9,20 +9,31 @@ import Foundation
 
 import RxSwift
 
-// TODO: - 서버 연결 시 재구현
 struct SignInModel {
     
-    func signIn(_ signInData: (String?, String?)) -> Single<Bool> {
-        return Observable
-            .just(true)
-            .asSingle()
+    typealias SignInInfo = (email: String, password: String)
+    
+    //MARK: - Properties
+    let network = SignInNetwork()
+    
+    //MARK: - Function
+    
+    func signIn(_ info: SignInInfo) -> Single<Result<Void, WanfError>> {
+        return network.signIn(email: info.email, password: info.password)
     }
     
-    func getSignInValue(_ result: Single<Bool>) -> Bool? {
-        return true
+    func getSignInValue(_ result: Result<Void, WanfError>) -> Void? {
+        guard case .success(let value) = result else {
+            return nil
+        }
+        return value
     }
     
-    func getSignInError(_ result: Single<Bool>) -> Void? {
-        return nil
+    func getSignInError(_ result: Result<Void, WanfError>) -> Void? {
+        guard case .failure(let error) = result else {
+            return nil
+        }
+        print("ERROR: \(error.localizedDescription)")
+        return Void()
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/SignInViewController/SignInViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignInViewController/SignInViewModel.swift
@@ -30,34 +30,30 @@ struct SignInViewModel {
         
         // 로그인 데이터 조합
         let signInData = Observable
-            .combineLatest(emailTextFieldViewModel.emailData, passwordTextFieldViewModel.passwordData)
+            .combineLatest(emailTextFieldViewModel.email, passwordTextFieldViewModel.password)
         
-        // 로그인 시도
+        // 로그인 버튼 - 로그인
         let signInResult = signInButtonTapped
             .withLatestFrom(signInData)
-            .map(model.signIn)
+            .flatMap(model.signIn)
             .share()
         
-        //로그인 성공
         let signInValue = signInResult
             .compactMap(model.getSignInValue)
         
-        //로그인 성공 시 메인 화면 전환
+        let signInError = signInResult
+            .compactMap(model.getSignInError)
+        
+        //로그인 성공 - 메인 화면 전환
         pushToMainTabBar = signInValue
             .map { _ in
                 return MainTabBarViewModel()
             }
             .asDriver(onErrorDriveWith: .empty())
         
-        //로그인 실패
-        let signInError = signInResult
-            .compactMap(model.getSignInError)
-        
-        // 로그인 시도 실패 시 Alert 표시
+        // 로그인 실패 - Alert 표시
         presentAlert = signInError
             .asSignal(onErrorSignalWith: .empty())
-        
-        
         
         // 회원가입 화면 전환
         pushToSignUpID = signUpButtonTapped

--- a/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/SignUp/SignUpIDViewController/SignUpIDViewModel.swift
@@ -60,8 +60,7 @@ struct SignUpIDViewModel {
         
         // 인증 번호 검증 성공
         pushToSignUpPassword = verificationValue
-            .withLatestFrom(emailStackViewCellViewModel.inputedIDText)
-            .compactMap { $0 }
+            .withLatestFrom(email)
             .map { email in SignUpPasswordViewModel(email: email) }
             .asDriver(onErrorDriveWith: .empty())
         


### PR DESCRIPTION
# 👩‍💻구현 내용
로그인 화면 서버 연결 구현 및
SignUp 회원가입 시 이메일 데이터 오류 수정

- 토큰 UserDefaults 저장
- UserDefaultsManager: UserDefaults를 관리하는 구조체
- UserDefaultsAuthorizationWrapper: Token을 관리하는 UserDefaults의 PropertyWrapper
- 로그인 버튼 Tap: 로그인 서버 연결

- SignUp ID 화면에서 Password 화면으로 전환 시 이메일 데이터 오류 수정

<br>

<br>
<br>

| 로그인 - 실패 | 로그인 - 성공 |
| ----- | ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/a9970b53-25d6-403f-a0b6-c5d9e1fe95b9" width = 350 height = 750> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/659d6106-5cc4-4171-9256-7def2e98a87a" width = 350 height = 750> |



<br>
#37 

