### PR TITLE
FriendsMatch Tab 화면: 서버 연결

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		142DBEDC29DC3D1100017603 /* SignInModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEDB29DC3D1100017603 /* SignInModel.swift */; };
 		142DBEDF29DC4DCE00017603 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEDE29DC4DCE00017603 /* MainTabBarController.swift */; };
 		142DBEE129DC4FC300017603 /* MainTabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */; };
+		143661FE2A0F7D7300308028 /* FriendsMatchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143661FD2A0F7D7300308028 /* FriendsMatchAPI.swift */; };
+		143662002A0F7F0500308028 /* FriendsMatchNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143661FF2A0F7F0500308028 /* FriendsMatchNetwork.swift */; };
 		144D30C32A0606F000640CCD /* ProfileSingleSelectionListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144D30C22A0606F000640CCD /* ProfileSingleSelectionListViewController.swift */; };
 		144D30C52A06076C00640CCD /* ProfileSingleSelectionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144D30C42A06076C00640CCD /* ProfileSingleSelectionListViewModel.swift */; };
 		144D30C72A06096000640CCD /* ProfileSingleSelectionListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144D30C62A06096000640CCD /* ProfileSingleSelectionListModel.swift */; };
@@ -132,6 +134,8 @@
 		142DBEDB29DC3D1100017603 /* SignInModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInModel.swift; sourceTree = "<group>"; };
 		142DBEDE29DC4DCE00017603 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		142DBEE029DC4FC300017603 /* MainTabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewModel.swift; sourceTree = "<group>"; };
+		143661FD2A0F7D7300308028 /* FriendsMatchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchAPI.swift; sourceTree = "<group>"; };
+		143661FF2A0F7F0500308028 /* FriendsMatchNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchNetwork.swift; sourceTree = "<group>"; };
 		144D30C22A0606F000640CCD /* ProfileSingleSelectionListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSingleSelectionListViewController.swift; sourceTree = "<group>"; };
 		144D30C42A06076C00640CCD /* ProfileSingleSelectionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSingleSelectionListViewModel.swift; sourceTree = "<group>"; };
 		144D30C62A06096000640CCD /* ProfileSingleSelectionListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSingleSelectionListModel.swift; sourceTree = "<group>"; };
@@ -346,6 +350,8 @@
 				144D30D42A06295100640CCD /* WanfNetwork.swift */,
 				1466FA1D2A0A412500910C30 /* AuthAPI.swift */,
 				1466FA1F2A0A428D00910C30 /* AuthNetwork.swift */,
+				143661FF2A0F7F0500308028 /* FriendsMatchNetwork.swift */,
+				143661FD2A0F7D7300308028 /* FriendsMatchAPI.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -725,6 +731,7 @@
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
 				14982C6E29EE580500D388BF /* FriendsMatchDetailInfoView.swift in Sources */,
 				1429B0AE29E53F9D00891FF8 /* FriendsMatchListCell.swift in Sources */,
+				143662002A0F7F0500308028 /* FriendsMatchNetwork.swift in Sources */,
 				144D30D92A068CE000640CCD /* SignUpNetwork.swift in Sources */,
 				14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */,
 				14066BB329E166B100AFB2D2 /* SignUpPasswordModel.swift in Sources */,
@@ -786,6 +793,7 @@
 				14D7A90A29E936A3007850BE /* FriendsMatchWritingLectureInfoView.swift in Sources */,
 				142DBEDF29DC4DCE00017603 /* MainTabBarController.swift in Sources */,
 				1496374129ED5ABD0021B4D4 /* FriendsMatchWriting.swift in Sources */,
+				143661FE2A0F7D7300308028 /* FriendsMatchAPI.swift in Sources */,
 				14DD372229DB30EC00D6A715 /* PasswordToCheckTextFieldCell.swift in Sources */,
 				144D30D72A06870F00640CCD /* SignUpAPI.swift in Sources */,
 				1496374329ED5E610021B4D4 /* FriendsMatchWritingModel.swift in Sources */,

--- a/WanF-Project/WanF-Project/Entity/FriendsMatchDetail.swift
+++ b/WanF-Project/WanF-Project/Entity/FriendsMatchDetail.swift
@@ -14,7 +14,3 @@ struct FriendsMatchDetail {
     let content: String
     let lectureInfo: LectureInfoModel
 }
-
-extension FriendsMatchDetail {
-    static let detailData = FriendsMatchDetail(nickname: "원프", date: "2023.05.03", title: "원프랑 같이 수업 들어요!", content: "WanF는 수업 친구 매칭 서비스로, 같이 수업을 듣고 정보를 공유할 친구를 찾을 수 있도록 장을 제공하는 성공회대학교 전용 플랫폼입니다.", lectureInfo: LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진"))
-}

--- a/WanF-Project/WanF-Project/Entity/FriendsMatchListCellModel.swift
+++ b/WanF-Project/WanF-Project/Entity/FriendsMatchListCellModel.swift
@@ -7,7 +7,21 @@
 
 import Foundation
 
-struct FriendsMatchListCellModel {
+struct FriendsMatchListCellModel: Decodable {
+    let id: Int
     let title: String
     let lectureInfo: LectureInfoModel
+    
+    enum CodingKeys: String, CodingKey {
+        case id, title
+        case lectureInfo = "course"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.lectureInfo = try container.decode(LectureInfoModel.self, forKey: .lectureInfo)
+    }
 }

--- a/WanF-Project/WanF-Project/Entity/LectureInfoModel.swift
+++ b/WanF-Project/WanF-Project/Entity/LectureInfoModel.swift
@@ -7,16 +7,22 @@
 
 import Foundation
 
-struct LectureInfoModel {
+struct LectureInfoModel: Decodable {
+    let id: Int
     let lectureName: String
     let professorName: String
-}
-
-extension LectureInfoModel {
-    static let lectureInfoCellData = [
-        LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진"),
-        LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진"),
-        LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진"),
-        LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진")
-    ]
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case lectureName = "name"
+        case professorName = "professor"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.lectureName = try container.decode(String.self, forKey: .lectureName)
+        self.professorName = try container.decode(String.self, forKey: .professorName)
+    }
 }

--- a/WanF-Project/WanF-Project/Network/FriendsMatchAPI.swift
+++ b/WanF-Project/WanF-Project/Network/FriendsMatchAPI.swift
@@ -1,0 +1,33 @@
+//
+//  FriendsMatchAPI.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/05/13.
+//
+
+import Foundation
+
+class FriendsMatchAPI: WanfAPI {
+    
+    //MARK: - Properties
+    let path = "/api/v1/posts"
+    let category = URLQueryItem(name: "category", value: "friend")
+    
+    init() {
+        super.init()
+    }
+    
+    //MARK: - Function
+    
+    // 전체 게시글 조회
+    func getAllPosts() -> URLComponents {
+        var components = URLComponents()
+        components.scheme = super.scheme
+        components.host = super.host
+        components.path = self.path
+        components.queryItems = [self.category]
+        
+        return components
+    }
+    
+}

--- a/WanF-Project/WanF-Project/Network/FriendsMatchNetwork.swift
+++ b/WanF-Project/WanF-Project/Network/FriendsMatchNetwork.swift
@@ -38,7 +38,7 @@ class FriendsMatchNetwork: WanfNetwork {
             .map { data in
                 do {
                     let decodedData = try JSONDecoder().decode([FriendsMatchListCellModel].self, from: data)
-                    print(decodedData)
+                    
                     return .success(decodedData)
                 }
                 catch {

--- a/WanF-Project/WanF-Project/Network/FriendsMatchNetwork.swift
+++ b/WanF-Project/WanF-Project/Network/FriendsMatchNetwork.swift
@@ -1,0 +1,54 @@
+//
+//  FriendsMatchNetwork.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/05/13.
+//
+
+import Foundation
+
+import RxSwift
+
+class FriendsMatchNetwork: WanfNetwork {
+    
+    //MARK: - Properties
+    let api = FriendsMatchAPI()
+    
+    init() {
+        super.init()
+    }
+    
+    //MARK: - Function
+    
+    // 전체 글 조회
+    func getAllPosts() -> Single<Result<[FriendsMatchListCellModel], WanfError>> {
+        guard let accessToken = UserDefaultsManager.accessToken else {
+            return .just(.failure(.invalidAuth))
+        }
+        
+        guard let url = api.getAllPosts().url else {
+            return .just(.failure(.invalidURL))
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(accessToken, forHTTPHeaderField: "Authorization")
+        
+        return session.rx.data(request: request)
+            .map { data in
+                do {
+                    let decodedData = try JSONDecoder().decode([FriendsMatchListCellModel].self, from: data)
+                    print(decodedData)
+                    return .success(decodedData)
+                }
+                catch {
+                    return .failure(.invalidJSON)
+                }
+            }
+            .catch({ error in
+                return .just(.failure(.networkError))
+            })
+            .asSingle()
+    }
+    
+}

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailModel.swift
@@ -22,7 +22,7 @@ struct FriendsMatchDetailModel {
         if !result {
             return nil
         }
-        return FriendsMatchDetail.detailData
+        return nil
     }
     
     func getDetailError(_ result: Bool) -> Bool? {

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabModel.swift
@@ -9,31 +9,28 @@ import Foundation
 
 import RxSwift
 
-// TODO: - 서버 연결 시 재구현
 struct FriendsMatchTabModel {
     
-    func loadFriendsMatchList() -> Observable<Bool> {
-        return Observable
-            .just(true)
+    let network = FriendsMatchNetwork()
+    
+    func loadFriendsMatchList() -> Single<Result<[FriendsMatchListCellModel], WanfError>> {
+        return network.getAllPosts()
     }
     
-    func getFriendsMatchListValue(_ result: Bool) -> [FriendsMatchListCellModel]? {
-        if !result {
+    func getFriendsMatchListValue(_ result: Result<[FriendsMatchListCellModel], WanfError>) -> [FriendsMatchListCellModel]? {
+        guard case .success(let value) = result else {
             return nil
         }
-        return [
-            FriendsMatchListCellModel(title: "원프에서 같이 수업 들을 사람 구해요!", lectureInfo: LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진")),
-            FriendsMatchListCellModel(title: "원프에서 같이 수업 들을 사람 구해요!", lectureInfo: LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진")),
-            FriendsMatchListCellModel(title: "원프에서 같이 수업 들을 사람 구해요!", lectureInfo: LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진")),
-            FriendsMatchListCellModel(title: "원프에서 같이 수업 들을 사람 구해요!", lectureInfo: LectureInfoModel(lectureName: "소프트웨어 캡스톤 디자인", professorName: "이승진"))
-        ]
+        return value
     }
     
-    func getFriendsMatchListError(_ result: Bool) -> Bool? {
-        if result {
+    func getFriendsMatchListError(_ result: Result<[FriendsMatchListCellModel], WanfError>) -> Void? {
+        guard case .failure(let error) = result else {
             return nil
         }
-        return false
+        let errorDescription = (error as NSError)
+        print("ERROR: \(errorDescription.code) \(errorDescription.localizedDescription)")
+        return Void()
     }
     
 }

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
@@ -70,11 +70,6 @@ class FriendsMatchTabViewController: UIViewController {
             .disposed(by: disposeBag)
         
         // ViewModel -> View
-        // TODO: - 데이터 연결 이벤트 전달 로직 수정 필요
-        viewModel.shouldLoadFriendsMatchList
-            .subscribe()
-            .disposed(by: disposeBag)
-        
         viewModel.pushToProfile
             .drive(onNext: { viewModel in
                 let profileVC = ProfileMainViewController()

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewModel.swift
@@ -18,7 +18,6 @@ struct FriendsMatchTabViewModel {
     let friendsMatchListItemSelected = PublishRelay<IndexPath>()
     
     // ViewModel -> View
-    let shouldLoadFriendsMatchList:  Observable<Bool>
     let cellData: Driver<[FriendsMatchListCellModel]>
     
     let pushToProfile: Driver<ProfileMainViewModel>
@@ -46,9 +45,8 @@ struct FriendsMatchTabViewModel {
         // ViewModel -> View
         
         //친구 찾기 List 데이터
-        shouldLoadFriendsMatchList = model.loadFriendsMatchList()
-        
-        let friendsMatchListResult = shouldLoadFriendsMatchList
+        let friendsMatchListResult = model.loadFriendsMatchList()
+            .asObservable()
             .share()
         
         let friendsMatchListValue = friendsMatchListResult

--- a/WanF-Project/WanF-Project/Presentation/LectureInfo/LectureInfoViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/LectureInfo/LectureInfoViewModel.swift
@@ -29,7 +29,7 @@ struct LectureInfoViewModel {
         
         // ViewModel -> View
         cellData = Observable
-            .just(LectureInfoModel.lectureInfoCellData)
+            .just([])
             .asDriver(onErrorJustReturn: [])
         
         //아이템 선택 시 dismiss되도록


### PR DESCRIPTION
# 👩‍💻구현 내용
수업 친구 찾기 전체 글 조회 서버 연결

- FriendsMatchListCellModel: 변수 추가, Decodable 타입 변경, CodingKeys 적용
- LectureInfo: 변수 추가, Decodable 타입 변경 및 CodingKeys 적용
- 더미 데이터 삭제
- 수업 친구 찾기 전체 글 조회 API와 Network 구현
- 수업 친구 찾기 전체 글 조회 서버 연결

<br>

### ❗️이슈
Entity 변경 및 더미 데이터 삭제로 서버 연결이 아직 이루어지지 않은 화면에서 데이터가 없어 UI가 나타나지 않을 수 있다.

<br>
<br>

| 수업 친구 찾기-전체 글 조회 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/5f2a46b6-7fc9-407d-876c-7de0b3dd8a15" width = 350 height = 750> |



<br>
#41  

