### PR TITLE
FriendsMatch Tab 화면: 새로고침 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
@@ -126,8 +126,6 @@ class FriendsMatchTabViewController: UIViewController {
                 return cell
             }
             .disposed(by: disposeBag)
-        
-//        friednsMatchTableView.rx.
     }
 }
 private extension FriendsMatchTabViewController {

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
@@ -45,6 +45,8 @@ class FriendsMatchTabViewController: UIViewController {
         return tableView
     }()
     
+    lazy var refreshControl = UIRefreshControl()
+    
     //MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -58,6 +60,15 @@ class FriendsMatchTabViewController: UIViewController {
         
         // Load a list
         viewModel.loadFriendsMatchList.onNext(Void())
+        
+        // Refresh the list
+        refreshControl.rx.controlEvent(.valueChanged)
+            .bind {[weak self] _ in
+                viewModel.subject.onNext(viewModel.refreshFriendsMatchList)
+                viewModel.refreshFriendsMatchList.onNext(Void())
+                self?.refreshControl.endRefreshing()
+            }
+            .disposed(by: disposeBag)
         
         // View -> ViewModel
         profileBarItem.rx.tap
@@ -107,7 +118,6 @@ class FriendsMatchTabViewController: UIViewController {
     func bindTableView(_ viewModel: FriendsMatchTabViewModel) {
         viewModel.cellData
             .drive(friednsMatchTableView.rx.items) { tv, row, element in
-                
                 guard let cell = tv.dequeueReusableCell(withIdentifier: "FriendsMatchListCell", for: IndexPath(row: row, section: 0)) as? FriendsMatchListCell else { return UITableViewCell() }
                 
                 cell.selectionStyle = .none
@@ -116,6 +126,8 @@ class FriendsMatchTabViewController: UIViewController {
                 return cell
             }
             .disposed(by: disposeBag)
+        
+//        friednsMatchTableView.rx.
     }
 }
 private extension FriendsMatchTabViewController {
@@ -134,6 +146,8 @@ private extension FriendsMatchTabViewController {
     }
     
     func layout() {
+        friednsMatchTableView.refreshControl = refreshControl
+        
         view.addSubview(friednsMatchTableView)
         
         friednsMatchTableView.snp.makeConstraints { make in

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewModel.swift
@@ -19,9 +19,11 @@ struct FriendsMatchTabViewModel {
     let addButtonTapped = PublishRelay<Void>()
     let friendsMatchListItemSelected = PublishRelay<IndexPath>()
     let loadFriendsMatchList = PublishSubject<Void>()
+    let refreshFriendsMatchList = PublishSubject<Void>()
     
     // ViewModel -> View
     let cellData: Driver<[FriendsMatchListItemEntity]>
+    let subject = PublishSubject<Observable<Void>>()
     
     let pushToProfile: Driver<ProfileMainViewModel>
     let presentFriendsMatchWriting: Driver<FriendsMatchWritingViewModel>
@@ -38,11 +40,15 @@ struct FriendsMatchTabViewModel {
             .asDriver(onErrorDriveWith: .empty())
         
         //친구 찾기 List 데이터
-        let friendsMatchListResult = loadFriendsMatchList
+        let friendsMatchListResult = subject
+            .switchLatest()
             .flatMap(model.loadFriendsMatchList)
             .share()
         
         friendsMatchListResult.subscribe().disposed(by: disposeBag)
+        
+        subject.onNext(loadFriendsMatchList)
+        loadFriendsMatchList.onNext(Void())
         
         let friendsMatchListValue = friendsMatchListResult
             .compactMap(model.getFriendsMatchListValue)


### PR DESCRIPTION
# 👩‍💻구현 내용
수업 친구 찾기 Tab 화면 새로고침 기능 구현

-  전체 글 목록 TableView에 RefreshControl를 설정하여 위로 스크롤 시 refresh 작동
- switchLatest를 사용해 기존 전체 글 목록 조회 서버 연결 로직에 refresh 로직 조합

<br>


<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/dc371d45-b3c8-4ae7-a87a-eae63783d86a" width = 350 height = 750> |

<br>
#54  

