### PR TITLE
ProfileMain 화면: 새로고침 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMainViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMainViewController.swift
@@ -13,6 +13,7 @@ import RxCocoa
 
 class ProfileMainViewController: UIViewController {
     
+    let disposeBag = DisposeBag()
     let profileContentView = ProfileContentView()
     var viewModel: ProfileMainViewModel?
     
@@ -30,6 +31,8 @@ class ProfileMainViewController: UIViewController {
         return label
     }()
     
+    let refreshControl = UIRefreshControl()
+    
     //MARK: -  LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -45,12 +48,23 @@ class ProfileMainViewController: UIViewController {
         
         // Bind Subcomponent
         profileContentView.bind(viewModel.profileContentViewModel)
+        
+        // Refresh
+        refreshControl.rx.controlEvent(.valueChanged)
+            .withLatestFrom(Observable.just(refreshControl))
+            .subscribe(onNext: { refreshControl in
+                viewModel.shouldRefreshProfile.accept(Void())
+                refreshControl.endRefreshing()
+            })
+            .disposed(by: disposeBag)
     }
 }
 
 private extension ProfileMainViewController {
     func configureView() {
         view.backgroundColor = .wanfBackground
+        
+        scrollView.refreshControl = refreshControl
         
         navigationItem.title = "프로필"
         navigationController?.navigationBar.titleTextAttributes = [

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMainViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMainViewModel.swift
@@ -19,15 +19,26 @@ struct ProfileMainViewModel {
     
     // View -> ViewModel
     let shouldPatchProfile = PublishRelay<ProfileContentWritingEntity>()
+    let shouldRefreshProfile = PublishRelay<Void>()
     
     init() {
         
+        // 프로필 수정
         shouldPatchProfile
             .withLatestFrom(Observable.just(profileContentViewModel), resultSelector: { profile, viewModel in
                 (profile, viewModel)
             })
             .subscribe(onNext: { profile, viewModel in
                 viewModel.patchProfile.accept(profile)
+            })
+            .disposed(by: disposeBag)
+        
+        // 프로필 새로고침
+        shouldRefreshProfile
+            .withLatestFrom(Observable.just(profileContentViewModel))
+            .subscribe(onNext: { viewModel in
+                viewModel.subject.onNext(viewModel.refreshProfileSubject)
+                viewModel.refreshProfileSubject.onNext(Void())
             })
             .disposed(by: disposeBag)
     }

--- a/WanF-Project/WanF-Project/Presentation/Profile/SubComponent/ProfileContentView.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/SubComponent/ProfileContentView.swift
@@ -203,7 +203,7 @@ class ProfileContentView: UIView {
                 
                 var gender = "성별"
                 if content.gender != nil {
-                    gender = content.gender!.keys.first!
+                    gender = content.gender!.values.first!
                 }
                 self.profileGenderLabel.text = gender
             })


### PR DESCRIPTION
# 👩‍💻구현 내용
프로필 화면 새로고침 기능 구현

-  새로고침 기능 구현
- switchLatest를 사용해 화면 로드와 새로고침 연결
- 성별 데이터 반영 정정(key(영어)->value(한글))

<br>

### ❗️이슈
mbti 프로필 수정 서버 연결 안 되어 있음

<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/1599cbb0-ae62-4d90-a77a-75329503e366" width = 350 height = 750> |



<br>
#57 

