### PR TITLE
ProfilePreview: 기능 구현 및 서버 연결

### DIFF
--- a/WanF-Project/WanF-Project/Network/ProfileNetwork/ProfileAPI.swift
+++ b/WanF-Project/WanF-Project/Network/ProfileNetwork/ProfileAPI.swift
@@ -35,6 +35,16 @@ class ProfilAPI: WanfAPI {
         return components
     }
     
+    // 특정 프로필 조회
+    func getSpecificProfile(_ id: Int) -> URLComponents {
+        var components = URLComponents()
+        components.scheme = super.scheme
+        components.host = super.host
+        components.path = self.path + "/\(id)"
+        
+        return components
+    }
+    
     // 목표 리스트 조회
     func getKeyworkGoalList() -> URLComponents {
         var components = URLComponents()

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailSubcomponents/FriendsMatchDetailInfo/FriendsMatchDetailInfoView.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailSubcomponents/FriendsMatchDetailInfo/FriendsMatchDetailInfoView.swift
@@ -17,7 +17,7 @@ class FriendsMatchDetailInfoView: UIView {
     let disposeBag = DisposeBag()
     
     //MARK: - View
-    private lazy var nicknameLabel: UILabel = {
+    lazy var nicknameLabel: UILabel = {
         let label = UILabel()
         
         label.text = "별명"

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
@@ -89,6 +89,16 @@ class FriendsMatchDetailViewController: UIViewController {
         viewModel.presentMenueActionSheet
             .emit(to: self.rx.presentMenueActionSheet)
             .disposed(by: disposeBag)
+        
+        // Present ProfilePreview
+        viewModel.presentProfilePreview
+            .drive(onNext: { id in
+                let profileProviewVC = ProfilePreviewViewController()
+                profileProviewVC.bind(ProfilePreviewViewModel(), id: id)
+                
+                self.present(profileProviewVC, animated: true)
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -168,10 +178,7 @@ extension FriendsMatchDetailViewController {
     }
     
     @objc func didTabNickname(){
-        let profileProviewVC = ProfilePreviewViewController()
-        profileProviewVC.bind(ProfilePreviewViewModel())
-        
-        self.present(profileProviewVC, animated: true)
+        viewModel?.didTabNickname.accept(Void())
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
@@ -58,6 +58,7 @@ class FriendsMatchDetailViewController: UIViewController {
         
         configureView()
         layout()
+        configureGesture()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -154,6 +155,23 @@ private extension FriendsMatchDetailViewController {
             height: contentHeight
         )
         scrollView.contentSize = contentView.frame.size
+    }
+}
+
+//MARK: - Tab Gesture
+extension FriendsMatchDetailViewController {
+    func configureGesture() {
+        
+        let nicknameGesture = UITapGestureRecognizer(target: self, action: #selector(didTabNickname))
+        detailInfoView.nicknameLabel.isUserInteractionEnabled = true
+        detailInfoView.nicknameLabel.addGestureRecognizer(nicknameGesture)
+    }
+    
+    @objc func didTabNickname(){
+        let profileProviewVC = ProfilePreviewViewController()
+        profileProviewVC.bind(ProfilePreviewViewModel())
+        
+        self.present(profileProviewVC, animated: true)
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewModel.swift
@@ -24,11 +24,13 @@ struct FriendsMatchDetailViewModel {
     let menueButtonTapped = PublishRelay<Void>()
     let deleteButtonTapped = BehaviorRelay(value: Void())
     let loadFriendsMatchDetail = PublishRelay<Void>()
+    let didTabNickname = PublishRelay<Void>()
     
     // ViewModel -> View
     let detailData: Observable<FriendsMatchDetailEntity>
     let presentMenueActionSheet: Signal<Void>
     let popToRootViewController: Driver<Void>
+    let presentProfilePreview: Driver<Int>
     
     // ViewModel -> ChildViewModel
     let detailInfo: Observable<(String, String)>
@@ -52,6 +54,13 @@ struct FriendsMatchDetailViewModel {
         detailData = loadDetailValue
             .share()
   
+        presentProfilePreview = Observable
+            .combineLatest(detailData, didTabNickname)
+            .map({ data, _ in
+                return data.profile.id
+            })
+            .asDriver(onErrorDriveWith: .empty())
+        
         detailInfo = detailData
             .map({ data in
                 (data.profile.nickname ?? "", data.date ?? "")

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentModel.swift
@@ -52,4 +52,24 @@ struct ProfileContentModel {
         print("ERROR: \(error)")
         return Void()
     }
+    
+    // 특정 프로필 조회
+    func loadProfilePreview(_ id: Int) -> Single<Result<ProfileContent, WanfError>> {
+        return network.getSpecificProfile(id)
+    }
+    
+    func getProfilePreviewValue(_ result: Result<ProfileContent, WanfError>) -> ProfileContent? {
+        guard case .success(let value) = result else {
+            return nil
+        }
+        return value
+    }
+    
+    func getProfilePreviewError(_ result: Result<ProfileContent, WanfError>) -> Void? {
+        guard case .failure(let error) = result else {
+            return nil
+        }
+        print("ERROR: \(error)")
+        return Void()
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
@@ -27,7 +27,7 @@ class ProfilePreviewViewController: UIViewController {
     }
     
     //MARK: - Function
-    func bind(_ viewModel: ProfilePreviewViewModel) {
+    func bind(_ viewModel: ProfilePreviewViewModel, id: Int) {
         // Bind Subcomponent View
         profileContentView.bind(viewModel.profileContentViewModel)
         

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
@@ -31,6 +31,9 @@ class ProfilePreviewViewController: UIViewController {
         // Bind Subcomponent View
         profileContentView.bind(viewModel.profileContentViewModel)
         
+        // Load Profile Preview
+        viewModel.shouldLoadProfilePreview.accept(id)
+        
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
@@ -15,7 +15,6 @@ class ProfilePreviewViewController: UIViewController {
     
     //MARK: - View
     let scrollView = UIScrollView()
-    let containerView = UIView()
     let profileContentView = ProfileContentView()
     
     //MARK: - LifeCycle
@@ -44,24 +43,21 @@ private extension ProfilePreviewViewController {
         view.backgroundColor = .wanfBackground
         
         view.addSubview(scrollView)
-        scrollView.addSubview(containerView)
-        containerView.addSubview(profileContentView)
+        scrollView.addSubview(profileContentView)
     }
     
     func layout() {
+        
+        let inset = 50.0
         
         scrollView.snp.makeConstraints { make in
             make.edges.equalTo(view.safeAreaLayoutGuide)
         }
         
-        containerView.snp.makeConstraints { make in
-            make.verticalEdges.equalToSuperview().inset(30)
-            make.horizontalEdges.equalToSuperview().inset(15)
-            make.width.equalTo(scrollView.snp.width).inset(15)
-        }
-        
         profileContentView.snp.makeConstraints { make in
-            make.top.horizontalEdges.equalToSuperview()
+            make.top.equalToSuperview().inset(inset)
+            make.horizontalEdges.equalToSuperview().inset(inset)
+            make.width.equalTo(scrollView.snp.width).inset(inset)
         }
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
@@ -12,15 +12,23 @@ import RxCocoa
 
 struct ProfilePreviewViewModel {
     
+    // Properties
+    let disposeBag = DisposeBag()
+    
     // Subcomponent ViewModel
     let profileContentViewModel = ProfileContentViewModel()
     
     // View -> ViewModel
+    let shouldLoadProfilePreview = PublishRelay<Int>()
     
     init() {
         
-        // Bind Subcomponent
-        
-        
+        // Load ProfilePreview
+        shouldLoadProfilePreview
+            .withLatestFrom(Observable.just(profileContentViewModel)) { ($0, $1)}
+            .subscribe(onNext: { id, viewModel in
+                viewModel.loadProfilePreview.accept(id)
+            })
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
# 👩‍💻구현 내용
프로필 미리보기 기능 구현 및 서버 연결

-  FriendsMatchDetail: 별명 클릭 시 프로필 미리보기 Present
- ProfileNetwork: <특정 게시글 조회> API 와 Network 구현 
- ProfileContent: amb를 사용하여 <나의 프로필 조회> 또는 <특정 프로필 조회>로 프로필 데이터 Load 로직 수정
- ProfilePreview: 데이터 Load 서버 연결 구현

<br>

- ProfilePreview: UI를 ProfileMain과 통일

<br>


<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/58c25df8-dac9-4dc7-b8b9-c4031d2b11b8" width = 350 height = 750> |




<br>
#61 

