### PR TITLE
ProfilePreview: 연락처 확인 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentViewModel.swift
@@ -22,6 +22,7 @@ struct ProfileContentViewModel {
     let refreshProfileSubject = PublishSubject<Void>()
     
     let loadProfilePreview = PublishRelay<Int>()
+    let shouldPresentActivoty = PublishRelay<String>()
     
     // ViewModel -> View
     let profileData: Driver<ProfileContent>

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentViewModel.swift
@@ -22,7 +22,6 @@ struct ProfileContentViewModel {
     let refreshProfileSubject = PublishSubject<Void>()
     
     let loadProfilePreview = PublishRelay<Int>()
-    let shouldPresentActivoty = PublishRelay<String>()
     
     // ViewModel -> View
     let profileData: Driver<ProfileContent>

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
@@ -13,6 +13,9 @@ import RxCocoa
 
 class ProfilePreviewViewController: UIViewController {
     
+    //MARK: - Properties
+    let disposeBag = DisposeBag()
+    
     //MARK: - View
     let scrollView = UIScrollView()
     let profileContentView = ProfileContentView()
@@ -32,6 +35,18 @@ class ProfilePreviewViewController: UIViewController {
         
         // Load Profile Preview
         viewModel.shouldLoadProfilePreview.accept(id)
+        
+        // Present ActivityView for Contact
+        profileContentView.profileContactButton.rx.tap
+            .bind(to: viewModel.shouldPresentActivity)
+            .disposed(by: disposeBag)
+        
+        viewModel.presentActivity
+            .drive(onNext: { contact in
+                let activityVC = UIActivityViewController(activityItems: [contact], applicationActivities: [])
+                self.present(activityVC, animated: true)
+            })
+            .disposed(by: disposeBag)
         
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
@@ -20,6 +20,10 @@ struct ProfilePreviewViewModel {
     
     // View -> ViewModel
     let shouldLoadProfilePreview = PublishRelay<Int>()
+    let shouldPresentActivity = PublishRelay<Void>()
+    
+    // ViewModel -> View
+    let presentActivity: Driver<String>
     
     init() {
         
@@ -30,5 +34,12 @@ struct ProfilePreviewViewModel {
                 viewModel.loadProfilePreview.accept(id)
             })
             .disposed(by: disposeBag)
+        
+        // Present ActivityView for Contact
+        presentActivity = shouldPresentActivity
+            .withLatestFrom(profileContentViewModel.profileData, resultSelector: { _, profile in
+                return profile.contact ?? ""
+            })
+            .asDriver(onErrorDriveWith: .empty())
     }
 }


### PR DESCRIPTION
# 👩‍💻구현 내용
프로필 미리보기 화면에 연락처 확인 기능 구현

-  UIActivityVC를 사용해 연락처 확인
- 연락처 버튼 클릭 시 UIActivityVC Present

<br>


<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/0a0ea712-91fb-4570-81bf-c897fea59040" width = 350 height = 750> |



<br>
#63  

