### PR TITLE
FriendaMatch Comment: 서버 연결

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		14840E4B29FE5CCC007BFB1A /* ProfileKeywordListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14840E4A29FE5CCC007BFB1A /* ProfileKeywordListViewModel.swift */; };
 		1484C75D2A1E1BD500014FD4 /* ExDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1484C75C2A1E1BD500014FD4 /* ExDateFormatter.swift */; };
 		14870BF129EBBD9400D9643E /* FriendsMatchWritingLectureInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14870BF029EBBD9400D9643E /* FriendsMatchWritingLectureInfoViewModel.swift */; };
+		14962D982A399CFF0049625C /* FriendsMatchCommentRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14962D972A399CFF0049625C /* FriendsMatchCommentRequestEntity.swift */; };
 		1496374129ED5ABD0021B4D4 /* FriendsMatchWritingEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1496374029ED5ABD0021B4D4 /* FriendsMatchWritingEntity.swift */; };
 		1496374329ED5E610021B4D4 /* FriendsMatchWritingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1496374229ED5E610021B4D4 /* FriendsMatchWritingModel.swift */; };
 		14982C6E29EE580500D388BF /* FriendsMatchDetailInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14982C6D29EE580500D388BF /* FriendsMatchDetailInfoView.swift */; };
@@ -197,6 +198,7 @@
 		14840E4A29FE5CCC007BFB1A /* ProfileKeywordListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileKeywordListViewModel.swift; sourceTree = "<group>"; };
 		1484C75C2A1E1BD500014FD4 /* ExDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExDateFormatter.swift; sourceTree = "<group>"; };
 		14870BF029EBBD9400D9643E /* FriendsMatchWritingLectureInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchWritingLectureInfoViewModel.swift; sourceTree = "<group>"; };
+		14962D972A399CFF0049625C /* FriendsMatchCommentRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchCommentRequestEntity.swift; sourceTree = "<group>"; };
 		1496374029ED5ABD0021B4D4 /* FriendsMatchWritingEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchWritingEntity.swift; sourceTree = "<group>"; };
 		1496374229ED5E610021B4D4 /* FriendsMatchWritingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchWritingModel.swift; sourceTree = "<group>"; };
 		14982C6D29EE580500D388BF /* FriendsMatchDetailInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchDetailInfoView.swift; sourceTree = "<group>"; };
@@ -450,6 +452,7 @@
 				1496374029ED5ABD0021B4D4 /* FriendsMatchWritingEntity.swift */,
 				14982C8029EE8BAC00D388BF /* FriendsMatchDetailEntity.swift */,
 				1449E1F92A13592A008C70DB /* FriendsMatchCommentEntity.swift */,
+				14962D972A399CFF0049625C /* FriendsMatchCommentRequestEntity.swift */,
 			);
 			path = FriendsMatch;
 			sourceTree = "<group>";
@@ -931,6 +934,7 @@
 				14870BF129EBBD9400D9643E /* FriendsMatchWritingLectureInfoViewModel.swift in Sources */,
 				1466FA242A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift in Sources */,
 				14DD371E29DB2CBB00D6A715 /* SignUpPasswordViewController.swift in Sources */,
+				14962D982A399CFF0049625C /* FriendsMatchCommentRequestEntity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WanF-Project/WanF-Project/Entity/FriendsMatch/FriendsMatchCommentRequestEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/FriendsMatch/FriendsMatchCommentRequestEntity.swift
@@ -1,0 +1,12 @@
+//
+//  FriendsMatchCommentRequestEntity.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/06/14.
+//
+
+import Foundation
+
+struct FriendsMatchCommentRequestEntity: Encodable {
+    let content: String
+}

--- a/WanF-Project/WanF-Project/Network/FriendsMatchNetwork/FriendsMatchAPI.swift
+++ b/WanF-Project/WanF-Project/Network/FriendsMatchNetwork/FriendsMatchAPI.swift
@@ -60,4 +60,14 @@ class FriendsMatchAPI: WanfAPI {
         
         return components
     }
+    
+    // 댓글 작성
+    func postComment(_ postId: Int) -> URLComponents {
+        var components = URLComponents()
+        components.scheme = super.scheme
+        components.host = super.host
+        components.path = self.path + "/\(postId)/comments"
+        
+        return components
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchComment/FriendsMatchCommentListViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchComment/FriendsMatchCommentListViewModel.swift
@@ -15,10 +15,12 @@ struct FriendsMatchCommentListViewModel {
     // ViewModel -> View
     let cellData: Driver<[FriendsMatchCommentEntity]>
     
+    // ParentViewModel -> ViewModel
+    let detailComments = PublishRelay<[FriendsMatchCommentEntity]>()
+    
     init() {
         
-        cellData = Observable
-            .just([])
-            .asDriver(onErrorJustReturn: [])
+        cellData = detailComments
+            .asDriver(onErrorDriveWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailModel.swift
@@ -53,4 +53,24 @@ struct FriendsMatchDetailModel {
         return Void()
     }
     
+    // Save the Comment
+    func postComment(_ postId: Int, content: FriendsMatchCommentRequestEntity) -> Single<Result<Void, WanfError>> {
+        return network.postComment(postId, content: content)
+    }
+    
+    func postCommentValue(_ result: Result<Void, WanfError>) -> Void? {
+        guard case .success(let value) = result else {
+            return nil
+        }
+        return value
+    }
+    
+    func postCommentError(_ result: Result<Void, WanfError>) -> Void? {
+        guard case .failure(let error) = result else {
+            return nil
+        }
+        print("ERROR: \(error)")
+        return Void()
+    }
+    
 }

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
@@ -135,7 +135,8 @@ class FriendsMatchDetailViewController: UIViewController {
                 
                 let cancelAction = UIAlertAction(title: "취소", style: .cancel)
                 let doneAction = UIAlertAction(title: "완료", style: .default) { _ in
-                    print("Save the Comment")
+                    guard let content = alert.textFields?.first?.text else { return }
+                    viewModel.shouldSaveComment.accept(FriendsMatchCommentRequestEntity(content: content))
                 }
                 
                 [

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewModel.swift
@@ -38,6 +38,7 @@ struct FriendsMatchDetailViewModel {
     let detailInfo: Observable<(String, String)>
     let detailLectureInfo: Observable<LectureInfoEntity>
     let detailText: Observable<(String, String)>
+    let detailComments: Observable<[FriendsMatchCommentEntity]>
     
     init(_ model: FriendsMatchDetailModel = FriendsMatchDetailModel(), id: Int) {
         
@@ -89,6 +90,15 @@ struct FriendsMatchDetailViewModel {
 
         detailText
             .bind(to: detailTextViewModel.detailText)
+            .disposed(by: disposeBag)
+        
+        detailComments = detailData
+            .map({ data in
+                return data.comments
+            })
+        
+        detailComments
+            .bind(to: commentListViewModel.detailComments)
             .disposed(by: disposeBag)
         
         // TODO: - 추후 구현


### PR DESCRIPTION
# 👩‍💻구현 내용
댓글 서버 연결

-  글 상세 서버 연결 시 응답으로 오는 댓글 목록 데이터 연결
- FriendsMatchCommentRequestEntity: 댓글 작성 요청 바디 Entity 생성
- FriendsMatchNetwork: 댓글 작성 API와 Network 메서드 구현
- 댓글 작성 서버 연결

<br>

### ❗️이슈
- 글 상세 새로 고침 기능 구현하면 좋을 듯!

<br>
<br>

| 댓글 목록 | 댓글 작성 |
| ----- |  ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/7ab9c437-c044-427d-886b-b60e48bd11f7" width = 350 height = 750> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/6a1d30a7-09c0-4618-b84d-64e46611bedc" width = 350 height = 750> |



<br>
#이슈번호 

