### PR TITLE
FriendsMatch Comment: 프로필 미리보기 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.xcworkspace/xcuserdata/limyunhwi.xcuserdatad/IDEFindNavigatorScopes.plist
+++ b/WanF-Project/WanF-Project.xcodeproj/project.xcworkspace/xcuserdata/limyunhwi.xcuserdatad/IDEFindNavigatorScopes.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchComment/FriendsMatchCommentListView.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchComment/FriendsMatchCommentListView.swift
@@ -63,8 +63,13 @@ class FriendsMatchCommentListView: DynamicSizeTableView {
                 
                 cell.contentConfiguration = configuration
                 cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-                
+                cell.selectionStyle = .none
             }
+            .disposed(by: disposeBag)
+        
+        // Present ProfilePreview
+        self.rx.itemSelected
+            .bind(to: viewModel.shouldPresentCommentProfile)
             .disposed(by: disposeBag)
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchComment/FriendsMatchCommentListViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchComment/FriendsMatchCommentListViewModel.swift
@@ -12,6 +12,11 @@ import RxCocoa
 
 struct FriendsMatchCommentListViewModel {
     
+    let disposeBag = DisposeBag()
+    
+    // View -> ViewModel
+    let shouldPresentCommentProfile = PublishRelay<IndexPath>()
+    
     // ViewModel -> View
     let cellData: Driver<[FriendsMatchCommentEntity]>
     

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
@@ -85,7 +85,7 @@ class FriendsMatchDetailViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-//        adjustContentViewSize()
+        adjustContentViewSize()
     }
     
     //MARK: - Function
@@ -215,17 +215,15 @@ private extension FriendsMatchDetailViewController {
             make.top.equalTo(midBarView.snp.bottom).offset(offset)
             make.bottom.equalToSuperview()
             make.horizontalEdges.equalToSuperview()
-            make.height.equalTo(500)
+            make.height.equalTo(0)
         }
     }
     
     func adjustContentViewSize() {
         let contentHeight = contentView.frame.height + commentListView.frame.height
-        contentView.frame.size = CGSize(
-            width: contentView.frame.width,
-            height: contentHeight
-        )
-        scrollView.contentSize = contentView.frame.size
+        commentListView.snp.updateConstraints { make in
+            make.height.equalTo(contentHeight)
+        }
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
@@ -85,7 +85,7 @@ class FriendsMatchDetailViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        adjustContentViewSize()
+//        adjustContentViewSize()
     }
     
     //MARK: - Function
@@ -215,6 +215,7 @@ private extension FriendsMatchDetailViewController {
             make.top.equalTo(midBarView.snp.bottom).offset(offset)
             make.bottom.equalToSuperview()
             make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(500)
         }
     }
     


### PR DESCRIPTION
# 👩‍💻구현 내용
수업 친구 찾기 글 상세 댓글 클릭 시 <프로필 미리보기> 화면 Present

-  '별명 클릭'에서 '아이템 선택'으로 로직 변경
- switchLatest를 사용해 '글 게시자 별명 선택'과 '댓글 선택'의 프로필 미리보기 작업 통합

<br>

### ❗️이슈
FIX: '댓글 높이 자동 조절'로 인해 아이템 클릭 이벤트 불가 오류로, 이와 관련하여 수정 완료

<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/15f5c214-2287-4815-99e6-05c568321b9d" width = 350 height = 750> |



<br>
#71 

