### PR TITLE
FriendsMatchSearch: 게시글 검색 기능, 서버

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		1466FA222A0A482B00910C30 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA212A0A482B00910C30 /* UserDefaultsManager.swift */; };
 		1466FA242A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */; };
 		146A01732A78D152004E140E /* FriendsMatchTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01722A78D152004E140E /* FriendsMatchTableView.swift */; };
+		146A01752A78E76B004E140E /* PageableEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01742A78E76B004E140E /* PageableEntity.swift */; };
 		146F1E632A22FC810095502F /* ProfileAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F1E622A22FC810095502F /* ProfileAPI.swift */; };
 		146F1E652A22FC8E0095502F /* ProfileNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F1E642A22FC8E0095502F /* ProfileNetwork.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
@@ -183,6 +184,7 @@
 		1466FA212A0A482B00910C30 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAuthorizationWrapper.swift; sourceTree = "<group>"; };
 		146A01722A78D152004E140E /* FriendsMatchTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchTableView.swift; sourceTree = "<group>"; };
+		146A01742A78E76B004E140E /* PageableEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableEntity.swift; sourceTree = "<group>"; };
 		146F1E622A22FC810095502F /* ProfileAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAPI.swift; sourceTree = "<group>"; };
 		146F1E642A22FC8E0095502F /* ProfileNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileNetwork.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
@@ -408,6 +410,7 @@
 				1429B0A229E5122400891FF8 /* PostListResponseEntity.swift */,
 				1496374029ED5ABD0021B4D4 /* PostRequestEntity.swift */,
 				14982C8029EE8BAC00D388BF /* PostResponseEntity.swift */,
+				146A01742A78E76B004E140E /* PageableEntity.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -900,6 +903,7 @@
 				147E9B532A178E520032E530 /* CourseAPI.swift in Sources */,
 				14E4C9EB29EA9FC600E2CB62 /* FriendsMatchWritingTopBarViewModel.swift in Sources */,
 				147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */,
+				146A01752A78E76B004E140E /* PageableEntity.swift in Sources */,
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
 				14982C6E29EE580500D388BF /* FriendsMatchDetailInfoView.swift in Sources */,
 				1429B0AE29E53F9D00891FF8 /* FriendsMatchListCell.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		1466FA242A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */; };
 		146A01732A78D152004E140E /* FriendsMatchTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01722A78D152004E140E /* FriendsMatchTableView.swift */; };
 		146A01752A78E76B004E140E /* PageableEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01742A78E76B004E140E /* PageableEntity.swift */; };
+		146A01772A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01762A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift */; };
 		146F1E632A22FC810095502F /* ProfileAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F1E622A22FC810095502F /* ProfileAPI.swift */; };
 		146F1E652A22FC8E0095502F /* ProfileNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F1E642A22FC8E0095502F /* ProfileNetwork.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
@@ -185,6 +186,7 @@
 		1466FA232A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsAuthorizationWrapper.swift; sourceTree = "<group>"; };
 		146A01722A78D152004E140E /* FriendsMatchTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchTableView.swift; sourceTree = "<group>"; };
 		146A01742A78E76B004E140E /* PageableEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableEntity.swift; sourceTree = "<group>"; };
+		146A01762A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlicePostPaginationResponseEntity.swift; sourceTree = "<group>"; };
 		146F1E622A22FC810095502F /* ProfileAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAPI.swift; sourceTree = "<group>"; };
 		146F1E642A22FC8E0095502F /* ProfileNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileNetwork.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 				1496374029ED5ABD0021B4D4 /* PostRequestEntity.swift */,
 				14982C8029EE8BAC00D388BF /* PostResponseEntity.swift */,
 				146A01742A78E76B004E140E /* PageableEntity.swift */,
+				146A01762A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -979,6 +982,7 @@
 				14840E4929FE5C8C007BFB1A /* ProfileKeywordListViewController.swift in Sources */,
 				14D7A90329E92F9B007850BE /* FriendsMatchWritingTopBarView.swift in Sources */,
 				144D30CD2A06259700640CCD /* WanfAPI.swift in Sources */,
+				146A01772A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift in Sources */,
 				14982C9129EEACD200D388BF /* FriendsMatchDetailModel.swift in Sources */,
 				1466FA1E2A0A412500910C30 /* AuthAPI.swift in Sources */,
 				14AC9B3929E27569009C37A5 /* ClassGroupViewController.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		146A01732A78D152004E140E /* FriendsMatchTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01722A78D152004E140E /* FriendsMatchTableView.swift */; };
 		146A01752A78E76B004E140E /* PageableEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01742A78E76B004E140E /* PageableEntity.swift */; };
 		146A01772A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01762A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift */; };
+		146A01792A78FC88004E140E /* FriendsMatchSearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146A01782A78FC88004E140E /* FriendsMatchSearchModel.swift */; };
 		146F1E632A22FC810095502F /* ProfileAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F1E622A22FC810095502F /* ProfileAPI.swift */; };
 		146F1E652A22FC8E0095502F /* ProfileNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146F1E642A22FC8E0095502F /* ProfileNetwork.swift */; };
 		147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */; };
@@ -187,6 +188,7 @@
 		146A01722A78D152004E140E /* FriendsMatchTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchTableView.swift; sourceTree = "<group>"; };
 		146A01742A78E76B004E140E /* PageableEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableEntity.swift; sourceTree = "<group>"; };
 		146A01762A78EF6E004E140E /* SlicePostPaginationResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlicePostPaginationResponseEntity.swift; sourceTree = "<group>"; };
+		146A01782A78FC88004E140E /* FriendsMatchSearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchSearchModel.swift; sourceTree = "<group>"; };
 		146F1E622A22FC810095502F /* ProfileAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAPI.swift; sourceTree = "<group>"; };
 		146F1E642A22FC8E0095502F /* ProfileNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileNetwork.swift; sourceTree = "<group>"; };
 		147922EC29DADBCF0052CBA8 /* SignUpIDViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDViewController.swift; sourceTree = "<group>"; };
@@ -797,6 +799,7 @@
 			children = (
 				14DEF35E2A7648440082BA27 /* FriendsMatchSearchViewController.swift */,
 				14DEF3602A7648830082BA27 /* FriendsMatchSearchViewModel.swift */,
+				146A01782A78FC88004E140E /* FriendsMatchSearchModel.swift */,
 			);
 			path = FriendsMatchSearch;
 			sourceTree = "<group>";
@@ -910,6 +913,7 @@
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
 				14982C6E29EE580500D388BF /* FriendsMatchDetailInfoView.swift in Sources */,
 				1429B0AE29E53F9D00891FF8 /* FriendsMatchListCell.swift in Sources */,
+				146A01792A78FC88004E140E /* FriendsMatchSearchModel.swift in Sources */,
 				147E1C2C2A2C841E00B42E4D /* ProfilePreviewViewController.swift in Sources */,
 				143662002A0F7F0500308028 /* FriendsMatchNetwork.swift in Sources */,
 				144D30D92A068CE000640CCD /* SignUpNetwork.swift in Sources */,

--- a/WanF-Project/WanF-Project/Custom/SCSearchBar/CSSearchBarView.swift
+++ b/WanF-Project/WanF-Project/Custom/SCSearchBar/CSSearchBarView.swift
@@ -50,6 +50,7 @@ class CSSearchBarView: UISearchBar {
 private extension CSSearchBarView {
     func configureView() {
         self.searchBarStyle = .minimal
+        self.tintColor = .wanfMint
     }
 }
 

--- a/WanF-Project/WanF-Project/Entity/Post/PageableEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/Post/PageableEntity.swift
@@ -1,0 +1,19 @@
+//
+//  PageableEntity.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/08/01.
+//
+
+import Foundation
+
+struct PageableEntity: Encodable {
+    let page: Int
+    let size: Int
+    let sort: [Sort]
+    
+    enum Sort: String, Encodable {
+        case empty = ""
+        case latest = "modifiedDate,DESC"
+    }
+}

--- a/WanF-Project/WanF-Project/Entity/Post/SlicePostPaginationResponseEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/Post/SlicePostPaginationResponseEntity.swift
@@ -1,0 +1,18 @@
+//
+//  SlicePostPaginationResponseEntity.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/08/01.
+//
+
+import Foundation
+
+struct SlicePostPaginationResponseEntity: Decodable {
+    let content: [PostListResponseEntity]
+    
+    let size: Int
+    let number: Int
+    let numberOfElements: Int
+    let last: Bool
+    let first: Bool
+}

--- a/WanF-Project/WanF-Project/Network/FriendsMatchNetwork/FriendsMatchAPI.swift
+++ b/WanF-Project/WanF-Project/Network/FriendsMatchNetwork/FriendsMatchAPI.swift
@@ -70,4 +70,23 @@ class FriendsMatchAPI: WanfAPI {
         
         return components
     }
+    
+    // 게시글 검색
+    func searchPosts(_ searchWord: String, pageable: PageableEntity) -> URLComponents {
+        let queryItems = [
+            self.category,
+            URLQueryItem(name: "query", value: searchWord),
+            URLQueryItem(name: "page", value: pageable.page.description),
+            URLQueryItem(name: "size", value: pageable.size.description),
+            URLQueryItem(name: "sort", value: pageable.sort.description)
+        ]
+        
+        var components = URLComponents()
+        components.scheme = super.scheme
+        components.host = super.host
+        components.path = self.path + "/search"
+        components.queryItems = queryItems
+        
+        return components
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchModel.swift
@@ -1,0 +1,36 @@
+//
+//  FriendsMatchSearchModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/08/01.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+struct FriendsMatchSearchModel {
+    
+    let network = FriendsMatchNetwork()
+    
+    // 게시글 검색
+    func searchPosts(_ searchWord: String, pageable: PageableEntity) -> Single<Result<SlicePostPaginationResponseEntity, WanfError>> {
+        return network.searchPosts(searchWord, pageable: pageable)
+    }
+    
+    func searchValue(_ result: Result<SlicePostPaginationResponseEntity, WanfError>) -> SlicePostPaginationResponseEntity? {
+        guard case .success(let value) = result else {
+            return nil
+        }
+        return value
+    }
+    
+    func searchError(_ result: Result<SlicePostPaginationResponseEntity, WanfError>) -> Void? {
+        guard case .failure(let error) = result else {
+            return nil
+        }
+        print("ERROR: \(error)")
+        return Void()
+    }
+}

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewController.swift
@@ -30,12 +30,11 @@ class FriendsMatchSearchViewController: UIViewController {
     //MARK: - Function
     func bind(_ viewModel: FriendsMatchSearchViewModel) {
         
-        // 임시 데이터
-        let posts = [
-            PostListResponseEntity(id: 0, title: "테스트1", course: CourseEntity(id: 0, name: "강의명1", professor: "교수명1")),
-            PostListResponseEntity(id: 0, title: "테스트2", course: CourseEntity(id: 0, name: "강의명2", professor: "교수명2"))
-        ]
-        Driver.just(posts)
+        // Bind Subcomponent
+        searchBar.bind(viewModel.searchBarViewModel)
+        
+        // Configure list
+        viewModel.cellData
             .drive(postTableView.rx.items(cellIdentifier: "FriendsMatchListCell", cellType: FriendsMatchListCell.self)){ row, element, cell in
                 cell.selectionStyle = .none
                 cell.setCellData(element)

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewController.swift
@@ -50,6 +50,7 @@ class FriendsMatchSearchViewController: UIViewController {
 private extension FriendsMatchSearchViewController {
     func configureView() {
         self.view.backgroundColor = .wanfBackground
+        searchBar.placeholder = "강의명을 입력하세요"
         
         [
             searchBar,

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewModel.swift
@@ -12,7 +12,40 @@ import RxCocoa
 
 struct FriendsMatchSearchViewModel {
     
-    init() {
+    let disposeBag = DisposeBag()
+    
+    // Subcomponent ViewModel
+    let searchBarViewModel = CSSearchBarViewModel()
+    
+    // ViewModel -> View
+    let cellData: Driver<[PostListResponseEntity]>
+    
+    init(_ model: FriendsMatchSearchModel = FriendsMatchSearchModel()) {
+        
+        // 검색
+        let searchResult = searchBarViewModel.shouldSearch
+            .asObservable()
+            .flatMap { searchWord in
+                model.searchPosts(searchWord, pageable: PageableEntity(page: 0, size: 3, sort: [.latest]))
+            }
+            .share()
+        
+        let searchValue = searchResult
+            .compactMap(model.searchValue)
+        
+        let searchError = searchResult
+            .compactMap(model.searchError)
+        
+        searchError
+            .subscribe()
+            .disposed(by: disposeBag)
+        
+        // 검색된 게시글 목록
+        cellData = searchValue
+            .map({ pageable in
+                pageable.content
+            })
+            .asDriver(onErrorDriveWith: .empty())
         
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchSearch/FriendsMatchSearchViewModel.swift
@@ -12,7 +12,9 @@ import RxCocoa
 
 struct FriendsMatchSearchViewModel {
     
+    //MARK: - Properties
     let disposeBag = DisposeBag()
+    let pageable = Observable.just(PageableEntity(page: 0, size: 10, sort: [.latest]))
     
     // Subcomponent ViewModel
     let searchBarViewModel = CSSearchBarViewModel()
@@ -22,11 +24,13 @@ struct FriendsMatchSearchViewModel {
     
     init(_ model: FriendsMatchSearchModel = FriendsMatchSearchModel()) {
         
+        // TODO: - Pageable하게 Refactoring
         // 검색
         let searchResult = searchBarViewModel.shouldSearch
             .asObservable()
-            .flatMap { searchWord in
-                model.searchPosts(searchWord, pageable: PageableEntity(page: 0, size: 3, sort: [.latest]))
+            .withLatestFrom(pageable) { (searchWord: $0, pageable: $1) }
+            .flatMap {
+                model.searchPosts($0.searchWord, pageable: $0.pageable)
             }
             .share()
         


### PR DESCRIPTION
# 👩‍💻구현 내용
강의 친구 찾기 게시글 검색 기능 및 서버 구현

-  CSSearchBarView: tintColor 설정
- FriendsMatchSearch: 검색바 placeholder 설정

<br>

- PageableEntity • SlicePostPaginationResponseEntity 생성
- FriendsMatchNetwork: 게시글 검색 API 및 network 구현
- FriendsMatchSearch: 검색 서버 연결 / 검색 결과 목록 데이터 반영

<br>

### ❗️이슈
Pageable 기능 구현 필요
- 일단 size 10으로 설정하여 hard-coded 했음

<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/0d5a109e-a1ee-4aa3-be0c-acaee735725d" width = 350 height = 750> |



<br>
#87 

