### PR TITLE
ClubList : 강의 모임 공유 기능 구현 및 서버 연결

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		14F52BC72A8DF32300A09F92 /* ClubNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BC62A8DF32300A09F92 /* ClubNetwork.swift */; };
 		14F52BC92A8DF8A500A09F92 /* ClubListTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BC82A8DF8A500A09F92 /* ClubListTableViewModel.swift */; };
 		14F52BCB2A8DFA9E00A09F92 /* ClubListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BCA2A8DFA9E00A09F92 /* ClubListModel.swift */; };
+		14F52BCD2A8E093E00A09F92 /* ClubPwdRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BCC2A8E093E00A09F92 /* ClubPwdRequestEntity.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -288,6 +289,7 @@
 		14F52BC62A8DF32300A09F92 /* ClubNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubNetwork.swift; sourceTree = "<group>"; };
 		14F52BC82A8DF8A500A09F92 /* ClubListTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubListTableViewModel.swift; sourceTree = "<group>"; };
 		14F52BCA2A8DFA9E00A09F92 /* ClubListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubListModel.swift; sourceTree = "<group>"; };
+		14F52BCC2A8E093E00A09F92 /* ClubPwdRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubPwdRequestEntity.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -908,6 +910,7 @@
 			isa = PBXGroup;
 			children = (
 				14F52BC12A8DEED800A09F92 /* ClubResponseEntity.swift */,
+				14F52BCC2A8E093E00A09F92 /* ClubPwdRequestEntity.swift */,
 			);
 			path = Club;
 			sourceTree = "<group>";
@@ -1020,6 +1023,7 @@
 				14E4C9EB29EA9FC600E2CB62 /* FriendsMatchWritingTopBarViewModel.swift in Sources */,
 				147922ED29DADBCF0052CBA8 /* SignUpIDViewController.swift in Sources */,
 				146A01752A78E76B004E140E /* PageableEntity.swift in Sources */,
+				14F52BCD2A8E093E00A09F92 /* ClubPwdRequestEntity.swift in Sources */,
 				142DBED029DC1DCB00017603 /* EmailTextField.swift in Sources */,
 				147823C82A7DF9F7003DC9CE /* CSKeyboardToolBar.swift in Sources */,
 				14982C6E29EE580500D388BF /* FriendsMatchDetailInfoView.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		14F52BC92A8DF8A500A09F92 /* ClubListTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BC82A8DF8A500A09F92 /* ClubListTableViewModel.swift */; };
 		14F52BCB2A8DFA9E00A09F92 /* ClubListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BCA2A8DFA9E00A09F92 /* ClubListModel.swift */; };
 		14F52BCD2A8E093E00A09F92 /* ClubPwdRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BCC2A8E093E00A09F92 /* ClubPwdRequestEntity.swift */; };
+		14F52BCF2A8E1E7E00A09F92 /* ClubShareInfoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F52BCE2A8E1E7E00A09F92 /* ClubShareInfoEntity.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -290,6 +291,7 @@
 		14F52BC82A8DF8A500A09F92 /* ClubListTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubListTableViewModel.swift; sourceTree = "<group>"; };
 		14F52BCA2A8DFA9E00A09F92 /* ClubListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubListModel.swift; sourceTree = "<group>"; };
 		14F52BCC2A8E093E00A09F92 /* ClubPwdRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubPwdRequestEntity.swift; sourceTree = "<group>"; };
+		14F52BCE2A8E1E7E00A09F92 /* ClubShareInfoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubShareInfoEntity.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -911,6 +913,7 @@
 			children = (
 				14F52BC12A8DEED800A09F92 /* ClubResponseEntity.swift */,
 				14F52BCC2A8E093E00A09F92 /* ClubPwdRequestEntity.swift */,
+				14F52BCE2A8E1E7E00A09F92 /* ClubShareInfoEntity.swift */,
 			);
 			path = Club;
 			sourceTree = "<group>";
@@ -1072,6 +1075,7 @@
 				14D4C2E329FD49B2001ACBC6 /* ProfileResponseEntity.swift in Sources */,
 				1484C75D2A1E1BD500014FD4 /* ExDateFormatter.swift in Sources */,
 				147E9B5A2A17942D0032E530 /* CourseInfoListModel.swift in Sources */,
+				14F52BCF2A8E1E7E00A09F92 /* ClubShareInfoEntity.swift in Sources */,
 				147E9B582A1792F30032E530 /* CourseEntity.swift in Sources */,
 				142DBEDC29DC3D1100017603 /* SignInModel.swift in Sources */,
 				14DD371129DB0EE700D6A715 /* SignUpIDViewModel.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		140917172A7CF66200B27131 /* ProfileKeywordSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140917162A7CF66200B27131 /* ProfileKeywordSettingViewModel.swift */; };
 		1409171D2A7D0B4000B27131 /* ProfileSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1409171C2A7D0B4000B27131 /* ProfileSettingViewModel.swift */; };
 		1409171F2A7D0B5800B27131 /* ProfileCreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1409171E2A7D0B5800B27131 /* ProfileCreateViewModel.swift */; };
+		141044CC2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */; };
 		141A781829D7ED46006731F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781729D7ED46006731F7 /* AppDelegate.swift */; };
 		141A781A29D7ED46006731F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781929D7ED46006731F7 /* SceneDelegate.swift */; };
 		141A782129D7ED46006731F7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 141A782029D7ED46006731F7 /* Assets.xcassets */; };
@@ -162,6 +163,7 @@
 		140917162A7CF66200B27131 /* ProfileKeywordSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileKeywordSettingViewModel.swift; sourceTree = "<group>"; };
 		1409171C2A7D0B4000B27131 /* ProfileSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewModel.swift; sourceTree = "<group>"; };
 		1409171E2A7D0B5800B27131 /* ProfileCreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCreateViewModel.swift; sourceTree = "<group>"; };
+		141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WanfShareAcitivityItemSource.swift; sourceTree = "<group>"; };
 		141A781429D7ED46006731F7 /* WanF-Project.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WanF-Project.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		141A781729D7ED46006731F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		141A781929D7ED46006731F7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -796,6 +798,7 @@
 				14D1FC502A7B733B00159E79 /* WanfTopButton.swift */,
 				146EA3412A8B522C005E010B /* ProfileBarButtonItem.swift */,
 				146EA3432A8B52FE005E010B /* AddBarButtonItem.swift */,
+				141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */,
 			);
 			path = Custom;
 			sourceTree = "<group>";
@@ -1016,6 +1019,7 @@
 			files = (
 				14793FBC29D837480048D5DD /* ExUIFont.swift in Sources */,
 				14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */,
+				141044CC2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift in Sources */,
 				14BD19EE29FBB63B00B0E598 /* ProfileContentViewModel.swift in Sources */,
 				140917152A7CF18C00B27131 /* ProfileKeywordSettingView.swift in Sources */,
 				14D4C2DD29FD0407001ACBC6 /* DynamicHeightCollectionView.swift in Sources */,

--- a/WanF-Project/WanF-Project/Custom/WanfShareAcitivityItemSource.swift
+++ b/WanF-Project/WanF-Project/Custom/WanfShareAcitivityItemSource.swift
@@ -12,9 +12,29 @@ import LinkPresentation
 class WanfShareActivityItemSource: NSObject, UIActivityItemSource {
     
     private let title: String
+    private var metadata = LPLinkMetadata()
     
     init(_ title: String) {
         self.title = title
+        super.init()
+        
+        configureLinkMetadata()
+    }
+    
+    func configureLinkMetadata() {
+        guard let url = Bundle.main.url(forResource: "WanF", withExtension: "plist"),
+              let dictionary = NSDictionary(contentsOf: url),
+              let value = dictionary["ShareURL"] as? String,
+              let url = URL(string: value)
+        else { return }
+        
+        metadata.originalURL = url
+        metadata.url = metadata.originalURL
+        metadata.title = self.title
+        
+        let representationImage = NSItemProvider(object: UIImage(named: "AppIcon") ?? UIImage())
+        metadata.imageProvider = representationImage
+        metadata.iconProvider = representationImage
     }
     
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
@@ -22,19 +42,10 @@ class WanfShareActivityItemSource: NSObject, UIActivityItemSource {
     }
     
     func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        return title
+        return metadata.url
     }
     
     func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
-        let metadata = LPLinkMetadata()
-        metadata.originalURL = URL(string: "https://github.com/WanF-Project/WanF-Project-iOS")
-        metadata.url = metadata.originalURL
-        metadata.title = self.title
-        
-        let representationImage = NSItemProvider(object: UIImage(named: "AppIcon") ?? UIImage())
-        metadata.imageProvider = representationImage
-        metadata.iconProvider = representationImage
-        
         return metadata
     }
 }

--- a/WanF-Project/WanF-Project/Custom/WanfShareAcitivityItemSource.swift
+++ b/WanF-Project/WanF-Project/Custom/WanfShareAcitivityItemSource.swift
@@ -1,0 +1,40 @@
+//
+//  WanfShareAcitivityItemSource.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/08/19.
+//
+
+import UIKit
+import LinkPresentation
+
+/// 강의 모임 공유 시 사용되는 Custom ActivituItemSource
+class WanfShareActivityItemSource: NSObject, UIActivityItemSource {
+    
+    private let title: String
+    
+    init(_ title: String) {
+        self.title = title
+    }
+    
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return title
+    }
+    
+    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        return title
+    }
+    
+    func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.originalURL = URL(string: "https://github.com/WanF-Project/WanF-Project-iOS")
+        metadata.url = metadata.originalURL
+        metadata.title = self.title
+        
+        let representationImage = NSItemProvider(object: UIImage(named: "AppIcon") ?? UIImage())
+        metadata.imageProvider = representationImage
+        metadata.iconProvider = representationImage
+        
+        return metadata
+    }
+}

--- a/WanF-Project/WanF-Project/Entity/Club/ClubPwdRequestEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/Club/ClubPwdRequestEntity.swift
@@ -1,0 +1,13 @@
+//
+//  ClubPwdRequestEntity.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/08/17.
+//
+
+import Foundation
+
+struct ClubPwdRequestEntity: Codable {
+    let id: Int
+    let password: String
+}

--- a/WanF-Project/WanF-Project/Entity/Club/ClubPwdRequestEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/Club/ClubPwdRequestEntity.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct ClubPwdRequestEntity: Codable {
-    let id: Int
+    let clubId: Int
     let password: String
 }

--- a/WanF-Project/WanF-Project/Entity/Club/ClubShareInfoEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/Club/ClubShareInfoEntity.swift
@@ -1,0 +1,15 @@
+//
+//  ClubShareInfoEntity.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/08/17.
+//
+
+import Foundation
+
+/// 모임 공유 정보 Entity
+struct ClubShareInfoEntity {
+    let clubName: String
+    let clubID: String
+    let clubPassword: String
+}

--- a/WanF-Project/WanF-Project/Entity/WanF.plist
+++ b/WanF-Project/WanF-Project/Entity/WanF.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ShareURL</key>
+	<string>https://github.com/WanF-Project</string>
 	<key>MBTI</key>
 	<array>
 		<string>INTJ</string>

--- a/WanF-Project/WanF-Project/Network/ClubNetwork/ClubAPI.swift
+++ b/WanF-Project/WanF-Project/Network/ClubNetwork/ClubAPI.swift
@@ -24,4 +24,14 @@ class ClubAPI: WanfAPI {
         
         return components
     }
+    
+    /// 모임 비밀번호 조회
+    func getClubPassword(_ clubID: Int) -> URLComponents {
+        var components = URLComponents()
+        components.scheme = super.scheme
+        components.host = super.host
+        components.path = self.path + "/\(clubID)/password"
+        
+        return components
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListModel.swift
@@ -33,4 +33,25 @@ struct ClubListModel {
         }
         return Void()
     }
+    
+    /// 모임 비밀번호 조회
+    func getClubPassword(_ clubID: Int) -> Single<Result<ClubPwdRequestEntity, WanfError>> {
+        return network.getClubPassword(clubID)
+    }
+    
+    /// 모임 비밀번호 조회 - 성공
+    func getClubPasswordValue(_ result: Result<ClubPwdRequestEntity, WanfError>) -> ClubPwdRequestEntity? {
+        guard case .success(let value) = result else {
+            return nil
+        }
+        return value
+    }
+    
+    /// 모임 비밀번호 조회 - 실패
+    func getClubPasswordError(_ result: Result<ClubPwdRequestEntity, WanfError>) -> Void? {
+        guard case .failure(let error) = result else {
+            return nil
+        }
+        return Void()
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableView.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableView.swift
@@ -36,6 +36,10 @@ class ClubListTableView: UITableView {
             .drive(self.rx.items(cellIdentifier: "ClubListTableViewCell", cellType: ClubListTableViewCell.self)){ row, element, cell  in
                 cell.configureCell(title: element.name)
                 cell.selectionStyle = .none
+                cell.shareButton.rx.tap
+                    .withLatestFrom(Observable.just(element))
+                    .bind(to: viewModel.shareButtonTapped)
+                    .disposed(by: self.disposeBag)
             }
             .disposed(by: disposeBag)
     }

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewCell.swift
@@ -32,7 +32,7 @@ class ClubListTableViewCell: UITableViewCell {
         return label
     }()
     
-    private lazy var shareButton: UIButton = {
+    lazy var shareButton: UIButton = {
         let button = UIButton()
         
         button.setImage(UIImage(systemName: "square.and.arrow.up"), for: .normal)

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewModel.swift
@@ -15,6 +15,9 @@ struct ClubListTableViewModel {
     // ParentViewModel -> ViewModel
     let shoulLoadClubs = PublishRelay<[ClubResponseEntity]>()
     
+    // View -> ViewModel
+    let shareButtonTapped = PublishRelay<ClubResponseEntity>()
+    
     // ViewModel -> View
     let cellData: Driver<[ClubResponseEntity]>
     

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
@@ -59,6 +59,11 @@ class ClubListViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        viewModel.presentShareActivity
+            .drive(onNext: { info in
+            })
+            .disposed(by: disposeBag)
+        
     }
     
     func presentAddActionSheet(_ viewModel: ClubListViewModel) {

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
@@ -61,6 +61,10 @@ class ClubListViewController: UIViewController {
         
         viewModel.presentShareActivity
             .drive(onNext: { info in
+                let title = "\(info.clubName) \n아이디: \(info.clubID) \n비밀번호: \(info.clubPassword)"
+                let activityItems = [WanfShareActivityItemSource(title)]
+                let activityVC = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+                self.present(activityVC, animated: true)
             })
             .disposed(by: disposeBag)
         

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
@@ -61,8 +61,11 @@ class ClubListViewController: UIViewController {
         
         viewModel.presentShareActivity
             .drive(onNext: { info in
-                let title = "\(info.clubName) \n아이디: \(info.clubID) \n비밀번호: \(info.clubPassword)"
-                let activityItems = [WanfShareActivityItemSource(title)]
+                let title = "\(info.clubName)"
+                let content = "모임 ID: \(info.clubID) \n비밀번호: \(info.clubPassword)"
+                let image = UIImage(named: "AppIcon") ?? UIImage()
+                
+                let activityItems = [WanfShareActivityItemSource(title), content, image]
                 let activityVC = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
                 self.present(activityVC, animated: true)
             })


### PR DESCRIPTION
# 👩‍💻구현 내용
강의 모임 목록의 공유 기능 구현 및 서버 연결

<서버 연결>
-  ClubPwdRequestEntity: 모임 비밀번호 조회 요청 Entity 생성
- ClubNetwork: 모임 비밀번호 조회 API 및 Network 구현

<br>

<기능 구현>
- WanfShareActivityItemSource: 모임 공유 정보 구성을 위한 커스텀 클래스 (Link Presentation 프레임워크 사용)
- ClubList: 모임 공유 버튼 클릭 시 비밀번호 조회 및 ActivityVC present

<br>

### ❗️이슈
추후 공유 링크 Test Flight로 변경하기

<br>
<br>

| 미리 보기 | 메세지 | 카톡 |
| ----- | ----- | ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/2a1a91c9-05f3-44b7-9fe1-5ca8ad7d78dc" width = 350 height = 500> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/70574ba2-1a7d-48b2-98ee-b081f4955c5b" width = 350 height = 500> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/32f61a66-da33-447f-8d63-72f2c4952f34" width = 350 height = 400> |



<br>
#98 

