### PR TITLE
[FIX] PrfofilePreview: 서버 연결 Canceled 오류

### DIFF
--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewController.swift
@@ -125,9 +125,9 @@ class FriendsMatchDetailViewController: UIViewController {
         
         // Present ProfilePreview
         viewModel.presentProfilePreview
-            .drive(onNext: { id in
+            .drive(onNext: { id, viewModel in
                 let profileProviewVC = ProfilePreviewViewController()
-                profileProviewVC.bind(ProfilePreviewViewModel(), id: id)
+                profileProviewVC.bind(viewModel, id: id)
                 
                 self.present(profileProviewVC, animated: true)
             })

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchDetail/FriendsMatchDetailViewModel.swift
@@ -41,7 +41,7 @@ struct FriendsMatchDetailViewModel {
     let detailData: Observable<PostResponseEntity>
     let presentMenueActionSheet: Signal<Void>
     let popToRootViewController: Driver<Void>
-    let presentProfilePreview: Driver<Int>
+    let presentProfilePreview: Driver<(Int, ProfilePreviewViewModel)>
     let presentCommentAlert: Driver<Void>
     
     // ViewModel -> ChildViewModel
@@ -70,6 +70,7 @@ struct FriendsMatchDetailViewModel {
         
         presentProfilePreview = commentSubject
             .switchLatest()
+            .map { ($0, ProfilePreviewViewModel()) }
             .asDriver(onErrorDriveWith: .empty())
         
         detailInfo = detailData

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileContentViewModel.swift
@@ -37,7 +37,6 @@ struct ProfileContentViewModel {
         
         let profileValue = loadProfileResult
             .compactMap(model.getProfileValue)
-            .share()
         
         let profileError = loadProfileResult
             .compactMap(model.getProfileError)
@@ -49,7 +48,6 @@ struct ProfileContentViewModel {
         
         let profilePreviewValue = loadProfilePreviewResult
             .compactMap(model.getProfilePreviewValue)
-            .share()
         
         let profilePreviewError = loadProfilePreviewResult
             .compactMap(model.getProfilePreviewError)

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
@@ -33,7 +33,7 @@ class ProfilePreviewViewController: UIViewController {
         profileContentView.bind(viewModel.profileContentViewModel)
         
         // Load Profile Preview
-        viewModel.shouldLoadProfilePreview.accept(id)
+        viewModel.profileContentViewModel.loadProfilePreview.accept(id)
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
@@ -12,24 +12,12 @@ import RxCocoa
 
 struct ProfilePreviewViewModel {
     
-    // Properties
-    let disposeBag = DisposeBag()
-    
     // Subcomponent ViewModel
     let profileContentViewModel = ProfileContentViewModel()
     
     // View -> ViewModel
-    let shouldLoadProfilePreview = PublishRelay<Int>()
-    let shouldPresentActivity = PublishRelay<Void>()
     
     init() {
         
-        // Load ProfilePreview
-        shouldLoadProfilePreview
-            .withLatestFrom(Observable.just(profileContentViewModel)) { ($0, $1)}
-            .subscribe(onNext: { id, viewModel in
-                viewModel.loadProfilePreview.accept(id)
-            })
-            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
# 👩‍💻구현 내용
프로필 미리보기 화면에서 View 생성 시점의 이유로 서버 연결 Canceld 발생

- 프로필 미리보기에 해당하는 각 Class의 ViewModel 생성 시점 변경
- 기타 불필요한 코드 삭제

<br>

<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/28b071fc-ab17-4fbc-bbbe-fffa36b1af82" width = 350 height = 750> |



<br>
#109 

