### PR TITLE
MessageDetail: 쪽지 상세 UI 구성

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		14567E9C29DFE824000B75EE /* EmailStackViewCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */; };
 		14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */; };
 		14567EA029E00AF6000B75EE /* SignUpIDModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */; };
+		145C7A632AA6EE6B002C5E53 /* MessageDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145C7A622AA6EE6B002C5E53 /* MessageDetailViewModel.swift */; };
 		1463ADE12A8C9182002845B8 /* ClubListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1463ADE02A8C9182002845B8 /* ClubListViewModel.swift */; };
 		1466FA1E2A0A412500910C30 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA1D2A0A412500910C30 /* AuthAPI.swift */; };
 		1466FA202A0A428D00910C30 /* AuthNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1466FA1F2A0A428D00910C30 /* AuthNetwork.swift */; };
@@ -244,6 +245,7 @@
 		14567E9B29DFE824000B75EE /* EmailStackViewCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStackViewCellModel.swift; sourceTree = "<group>"; };
 		14567E9D29E00740000B75EE /* VerifiedStackViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifiedStackViewCellViewModel.swift; sourceTree = "<group>"; };
 		14567E9F29E00AF6000B75EE /* SignUpIDModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpIDModel.swift; sourceTree = "<group>"; };
+		145C7A622AA6EE6B002C5E53 /* MessageDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailViewModel.swift; sourceTree = "<group>"; };
 		1463ADE02A8C9182002845B8 /* ClubListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubListViewModel.swift; sourceTree = "<group>"; };
 		1466FA1D2A0A412500910C30 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
 		1466FA1F2A0A428D00910C30 /* AuthNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNetwork.swift; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 				1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */,
 				1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */,
 				14121FDF2AA618B30059867B /* MessageDetailViewController.swift */,
+				145C7A622AA6EE6B002C5E53 /* MessageDetailViewModel.swift */,
 			);
 			path = Message;
 			sourceTree = "<group>";
@@ -1224,6 +1227,7 @@
 				1415DD922AA1D0BE00EF03A4 /* MessageListViewController.swift in Sources */,
 				14982C9529EEAD3600D388BF /* FriendsMatchDetailInfoViewModel.swift in Sources */,
 				1429B0A729E5163300891FF8 /* FriendsMatchTabViewModel.swift in Sources */,
+				145C7A632AA6EE6B002C5E53 /* MessageDetailViewModel.swift in Sources */,
 				1429B0A929E51CF400891FF8 /* FriendsMatchTabModel.swift in Sources */,
 				14AC9B3729E27547009C37A5 /* ClassInfoViewController.swift in Sources */,
 				14793FA929D831230048D5DD /* ExUIColor.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		141044CC2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */; };
 		14121FDA2AA5A1DB0059867B /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = 14121FD92AA5A1DB0059867B /* MessageKit */; };
 		14121FDC2AA5CDB50059867B /* MessageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14121FDB2AA5CDB50059867B /* MessageEntity.swift */; };
+		14121FE02AA618B30059867B /* MessageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14121FDF2AA618B30059867B /* MessageDetailViewController.swift */; };
 		1415DD922AA1D0BE00EF03A4 /* MessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */; };
 		1415DD942AA1D13A00EF03A4 /* MessageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */; };
 		1415DD972AA1D81000EF03A4 /* ChannelResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD962AA1D81000EF03A4 /* ChannelResponseEntity.swift */; };
@@ -187,6 +188,7 @@
 		1409171E2A7D0B5800B27131 /* ProfileCreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCreateViewModel.swift; sourceTree = "<group>"; };
 		141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WanfShareAcitivityItemSource.swift; sourceTree = "<group>"; };
 		14121FDB2AA5CDB50059867B /* MessageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEntity.swift; sourceTree = "<group>"; };
+		14121FDF2AA618B30059867B /* MessageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDetailViewController.swift; sourceTree = "<group>"; };
 		1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListViewController.swift; sourceTree = "<group>"; };
 		1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListViewModel.swift; sourceTree = "<group>"; };
 		1415DD962AA1D81000EF03A4 /* ChannelResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelResponseEntity.swift; sourceTree = "<group>"; };
@@ -369,6 +371,7 @@
 			children = (
 				1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */,
 				1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */,
+				14121FDF2AA618B30059867B /* MessageDetailViewController.swift */,
 			);
 			path = Message;
 			sourceTree = "<group>";
@@ -1261,6 +1264,7 @@
 				142DBEDC29DC3D1100017603 /* SignInModel.swift in Sources */,
 				14DD371129DB0EE700D6A715 /* SignUpIDViewModel.swift in Sources */,
 				14982C9929EEADC200D388BF /* FriendsMatchDetailTextViewModel.swift in Sources */,
+				14121FE02AA618B30059867B /* MessageDetailViewController.swift in Sources */,
 				14DD371329DB1DFB00D6A715 /* VerifiedStackViewCell.swift in Sources */,
 				14840E4B29FE5CCC007BFB1A /* ProfileKeywordListViewModel.swift in Sources */,
 				1429B0BA29E573B000891FF8 /* FriendsMatchWritingViewModel.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1409171F2A7D0B5800B27131 /* ProfileCreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1409171E2A7D0B5800B27131 /* ProfileCreateViewModel.swift */; };
 		141044CC2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */; };
 		14121FDA2AA5A1DB0059867B /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = 14121FD92AA5A1DB0059867B /* MessageKit */; };
+		14121FDC2AA5CDB50059867B /* MessageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14121FDB2AA5CDB50059867B /* MessageEntity.swift */; };
 		1415DD922AA1D0BE00EF03A4 /* MessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */; };
 		1415DD942AA1D13A00EF03A4 /* MessageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */; };
 		1415DD972AA1D81000EF03A4 /* ChannelResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD962AA1D81000EF03A4 /* ChannelResponseEntity.swift */; };
@@ -185,6 +186,7 @@
 		1409171C2A7D0B4000B27131 /* ProfileSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewModel.swift; sourceTree = "<group>"; };
 		1409171E2A7D0B5800B27131 /* ProfileCreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCreateViewModel.swift; sourceTree = "<group>"; };
 		141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WanfShareAcitivityItemSource.swift; sourceTree = "<group>"; };
+		14121FDB2AA5CDB50059867B /* MessageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageEntity.swift; sourceTree = "<group>"; };
 		1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListViewController.swift; sourceTree = "<group>"; };
 		1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListViewModel.swift; sourceTree = "<group>"; };
 		1415DD962AA1D81000EF03A4 /* ChannelResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelResponseEntity.swift; sourceTree = "<group>"; };
@@ -375,6 +377,7 @@
 			isa = PBXGroup;
 			children = (
 				1415DD962AA1D81000EF03A4 /* ChannelResponseEntity.swift */,
+				14121FDB2AA5CDB50059867B /* MessageEntity.swift */,
 			);
 			path = Message;
 			sourceTree = "<group>";
@@ -1240,6 +1243,7 @@
 				1455D2602A25B8940090257B /* MajorNetwork.swift in Sources */,
 				14A11A602A94BE48008453FC /* ImageNetwork.swift in Sources */,
 				14AC9B3529E2751C009C37A5 /* FriendsMatchTabViewController.swift in Sources */,
+				14121FDC2AA5CDB50059867B /* MessageEntity.swift in Sources */,
 				142DBED729DC2D2C00017603 /* PasswordTextFieldViewModel.swift in Sources */,
 				14F52BC72A8DF32300A09F92 /* ClubNetwork.swift in Sources */,
 				142DBED529DC2B0200017603 /* PasswordTextField.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1409171D2A7D0B4000B27131 /* ProfileSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1409171C2A7D0B4000B27131 /* ProfileSettingViewModel.swift */; };
 		1409171F2A7D0B5800B27131 /* ProfileCreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1409171E2A7D0B5800B27131 /* ProfileCreateViewModel.swift */; };
 		141044CC2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141044CB2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift */; };
+		14121FDA2AA5A1DB0059867B /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = 14121FD92AA5A1DB0059867B /* MessageKit */; };
 		1415DD922AA1D0BE00EF03A4 /* MessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */; };
 		1415DD942AA1D13A00EF03A4 /* MessageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */; };
 		1415DD972AA1D81000EF03A4 /* ChannelResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD962AA1D81000EF03A4 /* ChannelResponseEntity.swift */; };
@@ -345,6 +346,7 @@
 				141A783029D7F168006731F7 /* RxCocoa in Frameworks */,
 				141A783429D7F168006731F7 /* RxSwift in Frameworks */,
 				141A782D29D7F120006731F7 /* SnapKit in Frameworks */,
+				14121FDA2AA5A1DB0059867B /* MessageKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1107,6 +1109,7 @@
 				141A782F29D7F168006731F7 /* RxCocoa */,
 				141A783129D7F168006731F7 /* RxRelay */,
 				141A783329D7F168006731F7 /* RxSwift */,
+				14121FD92AA5A1DB0059867B /* MessageKit */,
 			);
 			productName = "WanF-Project";
 			productReference = 141A781429D7ED46006731F7 /* WanF-Project.app */;
@@ -1139,6 +1142,7 @@
 			packageReferences = (
 				141A782B29D7F120006731F7 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				141A782E29D7F168006731F7 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				14121FD82AA5A1DB0059867B /* XCRemoteSwiftPackageReference "MessageKit" */,
 			);
 			productRefGroup = 141A781529D7ED46006731F7 /* Products */;
 			projectDirPath = "";
@@ -1544,6 +1548,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		14121FD82AA5A1DB0059867B /* XCRemoteSwiftPackageReference "MessageKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/MessageKit/MessageKit";
+			requirement = {
+				kind = exactVersion;
+				version = 4.2.0;
+			};
+		};
 		141A782B29D7F120006731F7 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -1563,6 +1575,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		14121FD92AA5A1DB0059867B /* MessageKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 14121FD82AA5A1DB0059867B /* XCRemoteSwiftPackageReference "MessageKit" */;
+			productName = MessageKit;
+		};
 		141A782C29D7F120006731F7 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 141A782B29D7F120006731F7 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/WanF-Project/WanF-Project.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WanF-Project/WanF-Project.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "inputbaraccessoryview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nathantannar4/InputBarAccessoryView",
+      "state" : {
+        "revision" : "17ced92a5dccb36512b408b6276353631d7cbe57",
+        "version" : "6.3.0"
+      }
+    },
+    {
+      "identity" : "messagekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MessageKit/MessageKit",
+      "state" : {
+        "revision" : "1993e8e90d4e9a61b8d9bc8ceb733964ce943376",
+        "version" : "4.2.0"
+      }
+    },
+    {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift.git",

--- a/WanF-Project/WanF-Project/Entity/Message/MessageEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/Message/MessageEntity.swift
@@ -1,0 +1,25 @@
+//
+//  MessageEntity.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/09/04.
+//
+
+import Foundation
+
+import MessageKit
+
+struct MessageEntity: MessageType {
+    var sender: SenderType
+    var messageId: String
+    var sentDate: Date
+    let content: String
+    var kind: MessageKind {
+        .text(content)
+    }
+}
+
+struct SenderEntity: SenderType {
+    var senderId: String
+    var displayName: String
+}

--- a/WanF-Project/WanF-Project/Extension/ExDateFormatter.swift
+++ b/WanF-Project/WanF-Project/Extension/ExDateFormatter.swift
@@ -21,4 +21,10 @@ extension DateFormatter {
         return formatter.string(from: date)
     }
     
+    func wanfDateFormatted(from date: Date) -> String? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd h:mm a"
+        
+        return formatter.string(from: date)
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewController.swift
@@ -9,13 +9,15 @@ import UIKit
 
 import MessageKit
 import InputBarAccessoryView
+import RxSwift
+import RxCocoa
 
 class MessageDetailViewController: MessagesViewController {
     
     //MARK: - Properties
-    var sender = SenderEntity(senderId: "1", displayName: "name")
-    var messages: [MessageEntity] = [ MessageEntity(sender: SenderEntity(senderId: "2", displayName: "원프2"), messageId: "1234", sentDate: Date(), content: "수업 친구 매칭 서비스. 같이 수업을 듣고 정보를 공유할 친구를 찾을 수 있도록 장을 제공하는 성공회대학교 전용 플랫폼입니다."),
-                                      MessageEntity(sender: SenderEntity(senderId: "1", displayName: "원프1"), messageId: "1234", sentDate: Date(), content: "수업 친구 매칭 서비스. 같이 수업을 듣고 정보를 공유할 친구를 찾을 수 있도록 장을 제공하는 성공회대학교 전용 플랫폼입니다.")]
+    let disposeBag = DisposeBag()
+    var sender = SenderEntity(senderId: "", displayName: "")
+    var messages: [MessageEntity] = []
     
     //MARK: -  LifeCycle
     override func viewDidLoad() {
@@ -27,6 +29,24 @@ class MessageDetailViewController: MessagesViewController {
         
         messagesCollectionView.reloadData()
     }
+    
+    //MARK: - Function
+    func bind(_ viewModel: MessageDeatilViewModel) {
+        
+        // Bind Data
+        viewModel.messages
+            .drive(onNext: {
+                self.messages = $0
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.sender
+            .drive(onNext: {
+                self.sender = $0
+            })
+            .disposed(by: disposeBag)
+    }
+    
 }
 
 //MARK: - Configure

--- a/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewController.swift
@@ -1,0 +1,133 @@
+//
+//  MessageDetailViewController.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/09/04.
+//
+
+import UIKit
+
+import MessageKit
+import InputBarAccessoryView
+
+class MessageDetailViewController: MessagesViewController {
+    
+    //MARK: - Properties
+    var sender = SenderEntity(senderId: "1", displayName: "name")
+    var messages: [MessageEntity] = []
+    
+    //MARK: -  LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configure()
+        configureMessageCollectionView()
+        configureMessageInputBar()
+        
+        messagesCollectionView.reloadData()
+    }
+}
+
+//MARK: - Configure
+private extension MessageDetailViewController {
+    func configure() {
+        view.backgroundColor = .wanfBackground
+    }
+    
+    func configureMessageCollectionView() {
+        messagesCollectionView.messagesDataSource = self
+        messagesCollectionView.messagesDisplayDelegate = self
+        messagesCollectionView.messagesLayoutDelegate = self
+        
+        scrollsToLastItemOnKeyboardBeginsEditing = true
+    }
+    
+    func configureMessageInputBar() {
+        messageInputBar.delegate = self
+        
+        let key = NSAttributedString.Key.self
+        let attributesText = [
+            key.font : UIFont.wanfFont(ofSize: 15, weight: .regular),
+            key.foregroundColor : UIColor.wanfLabel
+        ]
+        let text = NSAttributedString(string: "", attributes: attributesText)
+        
+        messageInputBar.tintColor = .wanfMint
+        messageInputBar.sendButton.setTitle("전송", for: .normal)
+        messageInputBar.sendButton.setTitleColor(.wanfMint, for: .normal)
+        messageInputBar.inputTextView.attributedText = text
+    }
+}
+
+//MARK: - MessageKit Protocol
+extension MessageDetailViewController: MessagesDataSource {
+    var currentSender: MessageKit.SenderType {
+        return sender
+    }
+    
+    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessageKit.MessagesCollectionView) -> MessageKit.MessageType {
+        return messages[indexPath.section]
+    }
+    
+    func numberOfSections(in messagesCollectionView: MessageKit.MessagesCollectionView) -> Int {
+        return messages.count
+    }
+    
+    func messageTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let key = NSAttributedString.Key.self
+        let attributes = [
+            key.font : UIFont.wanfFont(ofSize: 15, weight: .bold),
+            key.foregroundColor : UIColor.wanfLabel
+        ]
+        return NSAttributedString(string: message.sender.displayName, attributes: attributes)
+    }
+    
+    func messageBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+        let key = NSAttributedString.Key.self
+        let attributes = [
+            key.font : UIFont.wanfFont(ofSize: 12, weight: .light),
+            key.foregroundColor : UIColor.wanfLabel
+        ]
+        let dateString = DateFormatter().wanfDateFormatted(from: message.sentDate) ?? ""
+        
+        return NSAttributedString(string: dateString, attributes: attributes)
+    }
+    
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {
+        avatarView.bounds.size = CGSize(width: 0, height: 0)
+    }
+    
+}
+
+extension MessageDetailViewController: MessagesDisplayDelegate, MessagesLayoutDelegate {
+    
+    func footerViewSize(for section: Int, in messagesCollectionView: MessagesCollectionView) -> CGSize {
+        return CGSize(width: 0, height: 8.0)
+    }
+    
+    func messageBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return CGFloat(30.0)
+    }
+    
+    func messageTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+        return CGFloat(30.0)
+    }
+    
+    func backgroundColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        return isFromCurrentSender(message: message) ? .wanfLightMint : .wanfLightGray
+    }
+    
+    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+        return .wanfLabel
+    }
+}
+
+//MARK: - InputBar Protocol
+extension MessageDetailViewController: InputBarAccessoryViewDelegate {
+    func inputBar(_ inputBar: InputBarAccessoryView, didPressSendButtonWith text: String) {
+        print("Press")
+    }
+}
+
+
+

--- a/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewController.swift
@@ -14,7 +14,8 @@ class MessageDetailViewController: MessagesViewController {
     
     //MARK: - Properties
     var sender = SenderEntity(senderId: "1", displayName: "name")
-    var messages: [MessageEntity] = []
+    var messages: [MessageEntity] = [ MessageEntity(sender: SenderEntity(senderId: "2", displayName: "원프2"), messageId: "1234", sentDate: Date(), content: "수업 친구 매칭 서비스. 같이 수업을 듣고 정보를 공유할 친구를 찾을 수 있도록 장을 제공하는 성공회대학교 전용 플랫폼입니다."),
+                                      MessageEntity(sender: SenderEntity(senderId: "1", displayName: "원프1"), messageId: "1234", sentDate: Date(), content: "수업 친구 매칭 서비스. 같이 수업을 듣고 정보를 공유할 친구를 찾을 수 있도록 장을 제공하는 성공회대학교 전용 플랫폼입니다.")]
     
     //MARK: -  LifeCycle
     override func viewDidLoad() {

--- a/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Message/MessageDetailViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  MessageDetailViewModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/09/05.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+struct MessageDeatilViewModel {
+    
+    // ViewModel -> View
+    var messages: Driver<[MessageEntity]>
+    var sender: Driver<SenderEntity>
+    
+    init() {
+        let data = [ MessageEntity(sender: SenderEntity(senderId: "2", displayName: "원프2"), messageId: "1234", sentDate: Date(), content: "수업 친구 매칭 서비스. 같이 수업을 듣고 정보를 공유할 친구를 찾을 수 있도록 장을 제공하는 성공회대학교 전용 플랫폼입니다."),
+                     MessageEntity(sender: SenderEntity(senderId: "1", displayName: "원프1"), messageId: "1234", sentDate: Date(), content: "수업 친구 매칭 서비스. 같이 수업을 듣고 정보를 공유할 친구를 찾을 수 있도록 장을 제공하는 성공회대학교 전용 플랫폼입니다.")]
+        messages = Observable.just(data)
+            .asDriver(onErrorDriveWith: .empty())
+        
+        sender = Observable.just(SenderEntity(senderId: "1", displayName: "Wanf"))
+            .asDriver(onErrorDriveWith: .empty())
+    }
+}


### PR DESCRIPTION
# 👩‍💻구현 내용
쪽지 상세 화면 UI 구성

-  SPM을 사용한 MessageKit 설치
- ExDataFormatter: wanfFormatted(from: Data) 생성
- MessageDetail: UI 구성

<br>

<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/be7dd9c3-f6bd-4f9c-8d8b-6210987f6eb3" width = 350 height = 750> |




<br>
#113 

