### PR TITLE
[FIX] MessageDetail: 날짜 및 정렬 오류

### DIFF
--- a/WanF-Project/WanF-Project/Entity/Message/MessageEntity.swift
+++ b/WanF-Project/WanF-Project/Entity/Message/MessageEntity.swift
@@ -20,7 +20,7 @@ struct MessageEntity: MessageType {
     
     init(sender: SenderType, sentDate: String, content: String) {
         self.sender = sender
-        self.sentDate = DateFormatter().date(from: sentDate) ?? Date()
+        self.sentDate = DateFormatter().wanfDateFormatted(from: sentDate) ?? Date()
         self.content = content
     }
 }

--- a/WanF-Project/WanF-Project/Extension/ExDateFormatter.swift
+++ b/WanF-Project/WanF-Project/Extension/ExDateFormatter.swift
@@ -27,4 +27,10 @@ extension DateFormatter {
         
         return formatter.string(from: date)
     }
+    
+    func wanfDateFormatted(from string: String) -> Date? {
+        self.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SS"
+        
+        return self.date(from: string)
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/Message/MessageDetail/MessageDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Message/MessageDetail/MessageDetailViewModel.swift
@@ -57,7 +57,7 @@ class MessageDetailViewModel {
                 response.messages.map {
                     let sender = SenderEntity(senderId: String($0.senderProfileId))
                     return MessageEntity(sender: sender, sentDate: $0.createDate, content: $0.content)
-                }
+                }.reversed()
             }
             .asDriver(onErrorDriveWith: .empty())
         


### PR DESCRIPTION
# 👩‍💻구현 내용
쪽지 상세 날짜 및 정렬 오류

-  ExDateFormatter: wanfDateFormatted(from: String) -> Date? 생성
- MessageDetail: 날짜 오류 수정, messages 역순 정렬

<br>

### ❗️이슈
- MessageDetail: 별명 NaviagtionBar title 반영 오류

<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/33f471d4-bffa-4c11-9edd-eefdd7fe9b48" width = 250 height = 550> |

<br>
#119 

