### PR TITLE
ProfilePreview: 쪽지 버튼 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailView.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailView.swift
@@ -196,6 +196,12 @@ class ProfileDetailView: ProfileTapBackgroundControl {
             .bind(to: viewModel.didTapMessageButton)
             .disposed(by: disposeBag)
         
+        viewModel.isEnableForMessageButton
+            .drive(onNext: {
+                self.profileMessageButton.isEnabled = $0
+            })
+            .disposed(by: disposeBag)
+        
         bindList(viewModel)
     }
     

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailView.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailView.swift
@@ -192,6 +192,10 @@ class ProfileDetailView: ProfileTapBackgroundControl {
             })
             .disposed(by: disposeBag)
         
+        profileMessageButton.rx.tap
+            .bind(to: viewModel.didTapMessageButton)
+            .disposed(by: disposeBag)
+        
         bindList(viewModel)
     }
     

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailViewModel.swift
@@ -15,10 +15,16 @@ struct ProfileDetailViewModel {
     // Parent ViewModel ->ViewModel
     let shouldBindProfile = PublishRelay<ProfileResponseEntity>()
     
+    // ViewModel -> Parent ViewModel
+    let shouldPushToMessageDetail: Signal<Int>
+    
     // ViewModel -> View
     let profile: Driver<ProfileResponseEntity>
     let personalityCellData: Driver<[String]>
     let purposeCellData: Driver<[String]>
+    
+    // View -> ViewModel
+    let didTapMessageButton = PublishRelay<Void>()
     
     init() {
         let value = shouldBindProfile
@@ -42,5 +48,11 @@ struct ProfileDetailViewModel {
                 return purpose
             })
             .asDriver(onErrorDriveWith: .empty())
+        
+        shouldPushToMessageDetail = didTapMessageButton
+            .withLatestFrom(profile, resultSelector: { _, profile in
+                profile.id
+            })
+            .asSignal(onErrorSignalWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/SubComponent/ProfileDetailViewModel.swift
@@ -22,6 +22,7 @@ struct ProfileDetailViewModel {
     let profile: Driver<ProfileResponseEntity>
     let personalityCellData: Driver<[String]>
     let purposeCellData: Driver<[String]>
+    let isEnableForMessageButton: Driver<Bool>
     
     // View -> ViewModel
     let didTapMessageButton = PublishRelay<Void>()
@@ -54,5 +55,17 @@ struct ProfileDetailViewModel {
                 profile.id
             })
             .asSignal(onErrorSignalWith: .empty())
+        
+        let myID = Observable.just(UserDefaultsManager.profileID)
+            .compactMap { $0 }
+        
+        isEnableForMessageButton = value
+            .withLatestFrom(myID) { profile, id in
+                if Int(id)! == profile.id {
+                    return false
+                }
+                return true
+            }
+            .asDriver(onErrorDriveWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewController.swift
@@ -34,6 +34,19 @@ class ProfilePreviewViewController: UIViewController {
         
         // Load Profile Preview
         viewModel.profileContentViewModel.loadProfilePreview.accept(id)
+        
+        // Push to MessageDetail
+        viewModel.pushToMessageDetail
+            .drive(onNext: { viewModel in
+                let MessageDetailVC = MessageDetailViewController()
+                guard let presentingVC = self.presentingViewController else { return }
+                
+                self.dismiss(animated: true) {
+                    MessageDetailVC.bind(viewModel)
+                    presentingVC.present(MessageDetailVC, animated: true)
+                }
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfilePreview/ProfilePreviewViewModel.swift
@@ -17,7 +17,16 @@ struct ProfilePreviewViewModel {
     
     // View -> ViewModel
     
+    // ViewModel -> View
+    let pushToMessageDetail: Driver<MessageDetailViewModel>
+    
     init() {
-        
+        pushToMessageDetail = profileContentViewModel.profileDefaultViewModel.profileDetailViewModel.shouldPushToMessageDetail
+            .map { id in
+                let messageDetailViewModel = MessageDetailViewModel()
+                messageDetailViewModel.id.accept(id)
+                return messageDetailViewModel
+            }
+            .asDriver(onErrorDriveWith: .empty())
     }
 }


### PR DESCRIPTION
# 👩‍💻구현 내용
쪽지 버튼 Tap 이벤트 및 비활성화 여부 구현

- 프로필이 본인일 경우 쪽지 버튼 비활성화
- 쪽지 버튼 Tap할 경우 MessageDetail 화면 전환

<br>
<br>
<br>

| 본인 프로필  | 타인 프로필 | 시연 |
| ----- | ----- | ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/2806d744-2190-4a1d-8989-d3e617dd6a12" width = 280 height = 500> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/de668558-e237-4ac2-a7e9-93b9569a4673" width = 280 height = 500> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/1f33ebed-66f1-4b1a-a7f6-78610e6bf45f" width = 250 height = 500> |




<br>
#131 

