### PR TITLE
ProfileEdit(프로필 수정): 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		1434E6262A7FA7AE0089BA3D /* SettingControlViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1434E6252A7FA7AE0089BA3D /* SettingControlViewModel.swift */; };
 		143661FE2A0F7D7300308028 /* FriendsMatchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143661FD2A0F7D7300308028 /* FriendsMatchAPI.swift */; };
 		143662002A0F7F0500308028 /* FriendsMatchNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143661FF2A0F7F0500308028 /* FriendsMatchNetwork.swift */; };
+		143857DF2ABABB5900A8F425 /* ExURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143857DE2ABABB5900A8F425 /* ExURL.swift */; };
 		14394D3C2A9C553400ACE540 /* ProfileDefaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14394D3B2A9C553400ACE540 /* ProfileDefaultViewModel.swift */; };
 		14394D402A9C5C4000ACE540 /* ProfileDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14394D3F2A9C5C4000ACE540 /* ProfileDetailViewModel.swift */; };
 		143AE33E2A738F8A00056647 /* CSSearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143AE33D2A738F8A00056647 /* CSSearchBarView.swift */; };
@@ -250,6 +251,7 @@
 		1434E6252A7FA7AE0089BA3D /* SettingControlViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingControlViewModel.swift; sourceTree = "<group>"; };
 		143661FD2A0F7D7300308028 /* FriendsMatchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchAPI.swift; sourceTree = "<group>"; };
 		143661FF2A0F7F0500308028 /* FriendsMatchNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsMatchNetwork.swift; sourceTree = "<group>"; };
+		143857DE2ABABB5900A8F425 /* ExURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExURL.swift; sourceTree = "<group>"; };
 		14394D3B2A9C553400ACE540 /* ProfileDefaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDefaultViewModel.swift; sourceTree = "<group>"; };
 		14394D3F2A9C5C4000ACE540 /* ProfileDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDetailViewModel.swift; sourceTree = "<group>"; };
 		143AE33D2A738F8A00056647 /* CSSearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSSearchBarView.swift; sourceTree = "<group>"; };
@@ -887,6 +889,7 @@
 				14797C302A84BDD50006C706 /* ExReactive.swift */,
 				14A11A572A94BA07008453FC /* ExNSMutableData.swift */,
 				14A11A592A94BB4A008453FC /* ExUIImage.swift */,
+				143857DE2ABABB5900A8F425 /* ExURL.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1310,6 +1313,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14793FBC29D837480048D5DD /* ExUIFont.swift in Sources */,
+				143857DF2ABABB5900A8F425 /* ExURL.swift in Sources */,
 				14567E9A29DFDD43000B75EE /* EmailStackViewCellViewModel.swift in Sources */,
 				144E6BDD2A936B8B005838EB /* ImageResponseEntity.swift in Sources */,
 				141044CC2A907C2500C51BD7 /* WanfShareAcitivityItemSource.swift in Sources */,

--- a/WanF-Project/WanF-Project/Extension/ExURL.swift
+++ b/WanF-Project/WanF-Project/Extension/ExURL.swift
@@ -14,6 +14,7 @@ extension URL {
         URLSession.shared.dataTask(with: self) { data, _, error in
             if let error = error {
                 debugPrint("ERROR: \(error)")
+                return
             }
             
             guard let data = data,

--- a/WanF-Project/WanF-Project/Extension/ExURL.swift
+++ b/WanF-Project/WanF-Project/Extension/ExURL.swift
@@ -1,0 +1,25 @@
+//
+//  ExURL.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/09/20.
+//
+
+import UIKit
+
+extension URL {
+    
+    /// URL을 UIImage로 변환하여 제공하는 메서드
+    public func image(_ completionHandler: @escaping (UIImage) -> Void) {
+        URLSession.shared.dataTask(with: self) { data, _, error in
+            if let error = error {
+                debugPrint("ERROR: \(error)")
+            }
+            
+            guard let data = data,
+                  let image = UIImage(data: data) else { return }
+            
+            completionHandler(image)
+        }.resume()
+    }
+}

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingView.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingView.swift
@@ -63,6 +63,8 @@ class ProfileSettingView: UIView {
         profileGoalView.bind(viewModel.goalSettingViewModel)
         
         // View -> ViewModel
+        viewModel.didLoadProfileSettingView.accept(Void())
+        
         settingPhotoButton.rx.tap
             .bind(to: viewModel.photoButtonTapped)
             .disposed(by: disposeBag)

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 import RxSwift
 import RxCocoa
@@ -30,11 +31,15 @@ class ProfileSettingViewModel {
     let personalitySettingViewModel = ProfileKeywordSettingViewModel()
     let goalSettingViewModel = ProfileKeywordSettingViewModel()
     
+    // Parent ViewModel -> ViewModel
+    let data = PublishRelay<ProfileResponseEntity>()
+    
     // ViewModel -> Parent ViewModel
     let shouldMakeDoneButtonActive: Signal<DoneButtonActiveData>
     let shouldPresentPhotoPicker: Driver<Void>
     
     // View -> ViewModel
+    let didLoadProfileSettingView = PublishRelay<Void>()
     let photoButtonTapped = PublishRelay<Void>()
     
     // ViewModel
@@ -43,6 +48,7 @@ class ProfileSettingViewModel {
     
     init() {
         
+        // Combine Date
         let imageInfo = settingPhotoButtonViewModel.imageData
             .compactMap { $0 }
         
@@ -93,5 +99,29 @@ class ProfileSettingViewModel {
         // Present Photo Picker
         shouldPresentPhotoPicker = photoButtonTapped
             .asDriver(onErrorDriveWith: .empty())
+        
+        // Bind Data
+        didLoadProfileSettingView
+            .withLatestFrom(data)
+            .withUnretained(self)
+            .subscribe(onNext: { (self, data) in
+                self.nameControlViewModel.stringValue.accept(data.nickname)
+                self.majorControlViewModel.nameableValue.accept(data.major)
+                self.studentIDControlViewModel.stringValue.accept(String(data.studentId))
+                self.ageControlViewModel.stringValue.accept(String(data.age))
+                self.genderControlViewModel.stringValue.accept(data.gender.values.first!)
+                self.mbtiControlViewModel.stringValue.accept(data.mbti)
+                
+                let personalities = data.personalities as NSDictionary
+                let personalityKeys = personalities.allKeys as? [String] ?? []
+                let personalityValues = personalities.allValues as? [String] ?? []
+                self.personalitySettingViewModel.keywords.accept(KeywordDictionary(personalityKeys, personalityValues))
+                
+                let goals = data.goals as NSDictionary
+                let goalKeys = goals.allKeys as? [String] ?? []
+                let goalValues = goals.allValues as? [String] ?? []
+                self.goalSettingViewModel.keywords.accept(KeywordDictionary(goalKeys, goalValues))
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingViewModel.swift
@@ -105,6 +105,11 @@ class ProfileSettingViewModel {
             .withLatestFrom(data)
             .withUnretained(self)
             .subscribe(onNext: { (self, data) in
+                if let url = URL(string: data.image.imageUrl) {
+                    url.image { image in
+                        self.settingPhotoButtonViewModel.shouldChangePreImage.accept(image)
+                    }
+                }
                 self.nameControlViewModel.stringValue.accept(data.nickname)
                 self.majorControlViewModel.nameableValue.accept(data.major)
                 self.studentIDControlViewModel.stringValue.accept(String(data.studentId))

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
@@ -6,10 +6,17 @@
 //
 
 import UIKit
+import PhotosUI
 
 import SnapKit
+import RxSwift
+import RxCocoa
 
 class ProfileEditViewController: UIViewController {
+    
+    var viewModel: ProfileEditViewModel?
+    let disposeBag = DisposeBag()
+    
     
     //MARK: - View
     let profileSettingView = ProfileSettingView()
@@ -32,8 +39,24 @@ class ProfileEditViewController: UIViewController {
     
     //MARK: - Function
     func bind(_ viewModel: ProfileEditViewModel) {
+        
+        self.viewModel = viewModel
+        
         // Bind Subcomponents
         profileSettingView.bind(viewModel.profileSettingViewModel)
+        
+        // View -> View
+        viewModel.presentPickerView
+            .drive(onNext: {
+                var configuration = PHPickerConfiguration()
+                configuration.filter = .images
+                configuration.selectionLimit = 1
+                
+                let photoPickerVC = PHPickerViewController(configuration: configuration)
+                photoPickerVC.delegate = self
+                self.present(photoPickerVC, animated: true)
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -49,5 +72,30 @@ private extension ProfileEditViewController {
         profileSettingView.snp.makeConstraints { make in
             make.edges.equalTo(view.safeAreaLayoutGuide)
         }
+    }
+}
+
+//MARK: - PHPickerViewControllerDelegate
+extension ProfileEditViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        
+        guard let selection = results.first else { return }
+        let imageProvider = selection.itemProvider
+        
+        if imageProvider.canLoadObject(ofClass: UIImage.self) {
+            imageProvider.loadObject(ofClass: UIImage.self) { image, error in
+                if let error = error {
+                    debugPrint("ERROR: \(error)")
+                    return
+                }
+
+                guard let image = image as? UIImage else { return }
+                DispatchQueue.main.async {
+                    self.viewModel?.profileSettingViewModel.settingPhotoButtonViewModel.shouldChangePreImage.accept(image)
+                }
+            }
+        }
+        
+        self.dismiss(animated: true)
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
@@ -35,6 +35,7 @@ class ProfileEditViewController: UIViewController {
         
         configure()
         layout()
+        setHandler()
     }
     
     //MARK: - Function
@@ -57,6 +58,85 @@ class ProfileEditViewController: UIViewController {
                 self.present(photoPickerVC, animated: true)
             })
             .disposed(by: disposeBag)
+    }
+    
+    func setHandler() {
+        
+        // Major
+        profileSettingView.majorControl.handler = {
+            let profileSingleSelectionListVC = ProfileSingleSelectionListViewController<MajorEntity>()
+            let profileSingleSelectionListViewModel = ProfileSingleSelectionListViewModel<MajorEntity>()
+            profileSingleSelectionListVC.bind(profileSingleSelectionListViewModel)
+            
+            profileSingleSelectionListViewModel.selectedData
+                .map { $0 as any Nameable }
+                .bind(to: self.viewModel!.profileSettingViewModel.majorControlViewModel.nameableValue)
+                .disposed(by: self.disposeBag)
+            
+            self.present(profileSingleSelectionListVC, animated: true)
+        }
+        
+        // Gender
+        profileSettingView.genderControl.handler = {
+            let handler: (UIAlertAction) -> Void = { action in
+                self.viewModel?.profileSettingViewModel.genderControlViewModel.stringValue.accept(action.title ?? "")
+            }
+            
+            let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+            let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+            let womanAction = UIAlertAction(title: "여자", style: .default, handler: handler)
+            let manAction = UIAlertAction(title: "남자", style: .default, handler: handler)
+            
+            [
+                cancelAction,
+                womanAction,
+                manAction
+            ]
+                .forEach { actionSheet.addAction($0) }
+            
+            self.present(actionSheet, animated: true)
+        }
+        
+        // MBTI
+        profileSettingView.mbtiControl.handler = {
+            let profileSingleSelectionListVC = ProfileSingleSelectionListViewController<MbtiEntity>()
+            let profileSingleSelectionListViewModel = ProfileSingleSelectionListViewModel<MbtiEntity>()
+            profileSingleSelectionListVC.bind(profileSingleSelectionListViewModel)
+            
+            profileSingleSelectionListViewModel.selectedData
+                .map { $0 as any Nameable }
+                .bind(to: self.viewModel!.profileSettingViewModel.mbtiControlViewModel.nameableValue)
+                .disposed(by: self.disposeBag)
+            
+            self.present(profileSingleSelectionListVC, animated: true)
+        }
+        
+        // Personality
+        profileSettingView.profilePersonalityView.handler = {
+            let profileKeywordListVC = ProfileKeywordListViewController()
+            let profileKeywordListViewModel = ProfileKeywordListViewModel(type: .personality)
+            profileKeywordListVC.bind(profileKeywordListViewModel)
+            
+            profileKeywordListViewModel.selectedData
+                .bind(to: self.viewModel!.profileSettingViewModel.personalitySettingViewModel.keywords)
+                .disposed(by: self.disposeBag)
+            
+            
+            self.present(profileKeywordListVC, animated: true)
+        }
+        
+        // Goal
+        profileSettingView.profileGoalView.handler = {
+            let profileKeywordListVC = ProfileKeywordListViewController()
+            let profileKeywordListViewModel = ProfileKeywordListViewModel(type: .purpose)
+            profileKeywordListVC.bind(profileKeywordListViewModel)
+            
+            profileKeywordListViewModel.selectedData
+                .bind(to: self.viewModel!.profileSettingViewModel.goalSettingViewModel.keywords)
+                .disposed(by: self.disposeBag)
+            
+            self.present(profileKeywordListVC, animated: true)
+        }
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
@@ -32,7 +32,8 @@ class ProfileEditViewController: UIViewController {
     
     //MARK: - Function
     func bind(_ viewModel: ProfileEditViewModel) {
-        
+        // Bind Subcomponents
+        profileSettingView.bind(viewModel.profileSettingViewModel)
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-struct ProfileEditViewModel {
+class ProfileEditViewModel {
     
     let disposeBag = DisposeBag()
     
@@ -20,10 +20,14 @@ struct ProfileEditViewModel {
     // ViewModel ->View
     let profile = PublishRelay<ProfileResponseEntity>()
     let data = PublishRelay<ProfileResponseEntity>()
+    let presentPickerView: Driver<Void>
     
     init() {
         data
             .bind(to: profileSettingViewModel.data)
             .disposed(by: disposeBag)
+        
+        presentPickerView = profileSettingViewModel.shouldPresentPhotoPicker
+            .asDriver(onErrorDriveWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
@@ -7,9 +7,23 @@
 
 import Foundation
 
+import RxSwift
+import RxCocoa
+
 struct ProfileEditViewModel {
     
+    let disposeBag = DisposeBag()
+    
+    // Subcomponent ViewModel
+    let profileSettingViewModel = ProfileSettingViewModel()
+    
+    // ViewModel ->View
+    let profile = PublishRelay<ProfileResponseEntity>()
+    let data = PublishRelay<ProfileResponseEntity>()
+    
     init() {
-        
+        data
+            .bind(to: profileSettingViewModel.data)
+            .disposed(by: disposeBag)
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
@@ -18,7 +18,6 @@ class ProfileEditViewModel {
     let profileSettingViewModel = ProfileSettingViewModel()
     
     // ViewModel ->View
-    let profile = PublishRelay<ProfileResponseEntity>()
     let data = PublishRelay<ProfileResponseEntity>()
     let presentPickerView: Driver<Void>
     

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/ProfileMainViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/ProfileMainViewModel.swift
@@ -24,9 +24,15 @@ struct ProfileMainViewModel {
     let pushToProfileEdit: Driver<ProfileEditViewModel>
     
     init() {
+        
+        let profile = profileContentViewModel.profileData
+        
         pushToProfileEdit = didTapEditBarItem
-            .map {
-                ProfileEditViewModel()
+            .withLatestFrom(profile)
+            .map { data in
+                let viewModel = ProfileEditViewModel()
+                viewModel.data.accept(data)
+                return viewModel
             }
             .asDriver(onErrorDriveWith: .empty())
     }


### PR DESCRIPTION
# 👩‍💻구현 내용
프로필 수정 기능 구현

- ExURL.image(completionHandler:(UIImage)->Void): url을 UIImage로 변환하여 제공하는 메서드 생성

-   프로필 데이터 가져오기
- 프로필 데이터 view 반영
- 사진 설정 버튼 이벤트
- SettingControlView 이벤트
- KeyworkSettingView 이벤트

<br>

### ❗️이슈
SettingControllView의 handler를 위한 setHandler를 MVVM에 맞춰 ViewModel로 옮기기

<br>
<br>

| 시연 | 미리 보기 |
| ----- | ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/535b2389-20f9-4c03-ad46-8b11015a5b58" width = 280 height = 550> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/a7a73668-1c4b-4a0c-a771-c463d9615628" width = 280 height = 550> |




<br>
#139 

