### PR TITLE
ProfileEdit(프로필 수정): 서버 연결

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		141A783229D7F168006731F7 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 141A783129D7F168006731F7 /* RxRelay */; };
 		141A783429D7F168006731F7 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 141A783329D7F168006731F7 /* RxSwift */; };
 		141A783629D7F1E5006731F7 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A783529D7F1E5006731F7 /* SignInViewController.swift */; };
+		142594DA2ABBF5A300B41333 /* ProfileEditModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142594D92ABBF5A300B41333 /* ProfileEditModel.swift */; };
 		1426B0462AB2C6ED00E43EA1 /* RandomFriendsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1426B0452AB2C6ED00E43EA1 /* RandomFriendsViewController.swift */; };
 		1426B0482AB2CADB00E43EA1 /* RandomFriendsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1426B0472AB2CADB00E43EA1 /* RandomFriendsViewModel.swift */; };
 		1426B0522AB308CC00E43EA1 /* RandomAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1426B0512AB308CC00E43EA1 /* RandomAPI.swift */; };
@@ -225,6 +226,7 @@
 		141A782329D7ED46006731F7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		141A782529D7ED46006731F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		141A783529D7F1E5006731F7 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
+		142594D92ABBF5A300B41333 /* ProfileEditModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditModel.swift; sourceTree = "<group>"; };
 		1426B0452AB2C6ED00E43EA1 /* RandomFriendsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomFriendsViewController.swift; sourceTree = "<group>"; };
 		1426B0472AB2CADB00E43EA1 /* RandomFriendsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomFriendsViewModel.swift; sourceTree = "<group>"; };
 		1426B0512AB308CC00E43EA1 /* RandomAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomAPI.swift; sourceTree = "<group>"; };
@@ -1016,6 +1018,7 @@
 			children = (
 				14A58B002AB95C2A004B4550 /* ProfileEditViewController.swift */,
 				14A58B022AB95E09004B4550 /* ProfileEditViewModel.swift */,
+				142594D92ABBF5A300B41333 /* ProfileEditModel.swift */,
 			);
 			path = ProfileEdit;
 			sourceTree = "<group>";
@@ -1473,6 +1476,7 @@
 				144D30C32A0606F000640CCD /* ProfileSingleSelectionListViewController.swift in Sources */,
 				1455D2622A25B8A00090257B /* MajorAPI.swift in Sources */,
 				14870BF129EBBD9400D9643E /* FriendsMatchWritingLectureInfoViewModel.swift in Sources */,
+				142594DA2ABBF5A300B41333 /* ProfileEditModel.swift in Sources */,
 				1466FA242A0A486C00910C30 /* UserDefaultsAuthorizationWrapper.swift in Sources */,
 				14DD371E29DB2CBB00D6A715 /* SignUpPasswordViewController.swift in Sources */,
 				140917172A7CF66200B27131 /* ProfileKeywordSettingViewModel.swift in Sources */,

--- a/WanF-Project/WanF-Project/Network/ProfileNetwork/ProfileNetwork.swift
+++ b/WanF-Project/WanF-Project/Network/ProfileNetwork/ProfileNetwork.swift
@@ -52,7 +52,7 @@ class ProfileNetwork: WanfNetwork {
     }
     
     // 나의 프로필 수정
-    func patchMyProfile(_ profile: ProfileRequestEntity) -> Single<Result<Void, WanfError>> {
+    func patchMyProfile(_ profile: ProfileImageRequestEntity) -> Single<Result<ProfileResponseEntity, WanfError>> {
         guard let url = api.patchMyProfile().url else {
             return .just(.failure(.invalidURL))
         }
@@ -73,8 +73,14 @@ class ProfileNetwork: WanfNetwork {
             .flatMap { request in
                 super.session.rx.data(request: request)
             }
-            .map { _ in
-                return .success(Void())
+            .map { data in
+                do {
+                    let decoded = try JSONDecoder().decode(ProfileResponseEntity.self, from: data)
+                    return .success(decoded)
+                }
+                catch {
+                    return .failure(.invalidJSON)
+                }
             }
             .catch { error in
                 return .just(.failure(.networkError))

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCeateSubcomponent/ProfileSettingView/ProfileSettingViewModel.swift
@@ -37,6 +37,7 @@ class ProfileSettingViewModel {
     // ViewModel -> Parent ViewModel
     let shouldMakeDoneButtonActive: Signal<DoneButtonActiveData>
     let shouldPresentPhotoPicker: Driver<Void>
+    let imageID = PublishRelay<Int>()
     
     // View -> ViewModel
     let didLoadProfileSettingView = PublishRelay<Void>()
@@ -50,7 +51,6 @@ class ProfileSettingViewModel {
         
         // Combine Date
         let imageInfo = settingPhotoButtonViewModel.imageData
-            .compactMap { $0 }
         
         let name = nameControlViewModel.stringValue
             .filter { !$0.isEmpty }
@@ -107,7 +107,8 @@ class ProfileSettingViewModel {
             .subscribe(onNext: { (self, data) in
                 if let url = URL(string: data.image.imageUrl) {
                     url.image { image in
-                        self.settingPhotoButtonViewModel.shouldChangePreImage.accept(image)
+                        self.settingPhotoButtonViewModel.shouldChangePreImageForEdit.accept(image)
+                        self.imageID.accept(data.image.imageId)
                     }
                 }
                 self.nameControlViewModel.stringValue.accept(data.nickname)

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCreateViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileCreate/ProfileCreateViewController.swift
@@ -90,7 +90,7 @@ class ProfileCreateViewController: UIViewController {
             itemProvider.loadObject(ofClass: UIImage.self) { item, error in
                 guard let image = item as? UIImage else { return }
                 DispatchQueue.main.async {
-                    self.viewModel?.profileSettingViewModel.settingPhotoButtonViewModel.shouldChangePreImage.accept(image)
+                    self.viewModel?.profileSettingViewModel.settingPhotoButtonViewModel.shouldChangePreImageForCreate.accept(image)
                 }
             }
         }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditModel.swift
@@ -32,4 +32,23 @@ struct ProfileEditModel {
         }
         return error
     }
+    
+    /// 프로필 수정
+    func editProfile(_ profile: ProfileImageRequestEntity) -> Single<Result<ProfileResponseEntity, WanfError>> {
+        return profileNetwork.patchMyProfile(profile)
+    }
+
+    func editProfileValue(_ result: Result<ProfileResponseEntity, WanfError>) -> ProfileResponseEntity? {
+        guard case .success(let value) = result else {
+            return nil
+        }
+        return value
+    }
+    
+    func editProfileError(_ result: Result<ProfileResponseEntity, WanfError>) -> WanfError? {
+        guard case .failure(let error) = result else {
+            return nil
+        }
+        return error
+    }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditModel.swift
@@ -1,0 +1,35 @@
+//
+//  ProfileEditModel.swift
+//  WanF-Project
+//
+//  Created by 임윤휘 on 2023/09/21.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+struct ProfileEditModel {
+    let imageNetwork = ImageNetwork()
+    let profileNetwork = ProfileNetwork()
+    
+    /// 이미지 업로드
+    func uploadImage(_ image: ImageInfo) -> Single<Result<ImageResponseEntity, WanfError>> {
+        return imageNetwork.postUploadImage(image: image, directory: .profiles)
+    }
+
+    func uploadImageValue(_ result: Result<ImageResponseEntity, WanfError>) -> ImageResponseEntity? {
+        guard case .success(let value) = result else {
+            return nil
+        }
+        return value
+    }
+    
+    func uploadImageError(_ result: Result<ImageResponseEntity, WanfError>) -> WanfError? {
+        guard case .failure(let error) = result else {
+            return nil
+        }
+        return error
+    }
+}

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
@@ -63,6 +63,12 @@ class ProfileEditViewController: UIViewController {
                 self.present(photoPickerVC, animated: true)
             })
             .disposed(by: disposeBag)
+        
+        viewModel.dismiss
+            .drive(onNext: {_ in
+                self.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
     }
     
     func setHandler() {

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
@@ -65,7 +65,8 @@ class ProfileEditViewController: UIViewController {
             .disposed(by: disposeBag)
         
         viewModel.dismiss
-            .drive(onNext: {_ in
+            .drive(onNext: {
+                viewModel.profileEdited.accept($0)
                 self.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposeBag)

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewController.swift
@@ -46,7 +46,12 @@ class ProfileEditViewController: UIViewController {
         // Bind Subcomponents
         profileSettingView.bind(viewModel.profileSettingViewModel)
         
-        // View -> View
+        // View -> ViewModel
+        doneBarItem.rx.tap
+            .bind(to: viewModel.didTapDoneButton)
+            .disposed(by: disposeBag)
+        
+        // ViewModel -> View
         viewModel.presentPickerView
             .drive(onNext: {
                 var configuration = PHPickerConfiguration()
@@ -171,7 +176,7 @@ extension ProfileEditViewController: PHPickerViewControllerDelegate {
 
                 guard let image = image as? UIImage else { return }
                 DispatchQueue.main.async {
-                    self.viewModel?.profileSettingViewModel.settingPhotoButtonViewModel.shouldChangePreImage.accept(image)
+                    self.viewModel?.profileSettingViewModel.settingPhotoButtonViewModel.shouldChangePreImageForCreate.accept(image)
                 }
             }
         }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
@@ -27,6 +27,7 @@ class ProfileEditViewModel {
     let presentPickerView: Driver<Void>
     let dismiss: Driver<ProfileResponseEntity>
     
+    let profileEdited = PublishRelay<ProfileResponseEntity>()
     
     init(_ model: ProfileEditModel = ProfileEditModel()) {
         data

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
@@ -17,16 +17,63 @@ class ProfileEditViewModel {
     // Subcomponent ViewModel
     let profileSettingViewModel = ProfileSettingViewModel()
     
-    // ViewModel ->View
+    let imageID = PublishRelay<Int>()
+    
+    // View -> ViewModel
+    let didTapDoneButton = PublishRelay<Void>()
+    
+    // ViewModel -> View
     let data = PublishRelay<ProfileResponseEntity>()
     let presentPickerView: Driver<Void>
     
-    init() {
+    init(_ model: ProfileEditModel = ProfileEditModel()) {
         data
             .bind(to: profileSettingViewModel.data)
             .disposed(by: disposeBag)
         
         presentPickerView = profileSettingViewModel.shouldPresentPhotoPicker
             .asDriver(onErrorDriveWith: .empty())
+        
+        // Upload Image
+        let profile = didTapDoneButton
+            .withLatestFrom(profileSettingViewModel.shouldMakeDoneButtonActive)
+            .map { $0.profile }
+            .asObservable()
+        
+        let imageInfo = didTapDoneButton
+            .withLatestFrom(profileSettingViewModel.shouldMakeDoneButtonActive)
+            .compactMap { $0.imageInfo }
+        
+        let imageResult = imageInfo
+            .flatMap(model.uploadImage)
+            .share()
+        
+        let imageValue = imageResult
+            .compactMap(model.uploadImageValue)
+            .map { $0.imageId }
+        
+        let imageError = imageResult
+            .compactMap(model.uploadImageError)
+        
+        imageError
+            .subscribe(onNext: {
+                print("Error: \($0)")
+            })
+            .disposed(by: disposeBag)
+        
+        let existingImageId = didTapDoneButton
+            .withLatestFrom(profileSettingViewModel.imageID)
+            .withLatestFrom(profileSettingViewModel.shouldMakeDoneButtonActive) { id, data in
+                if data.imageInfo == nil {
+                    return id
+                }
+                return nil
+            }
+            .compactMap { $0 }
+        
+        let imageID = imageValue
+            .amb(existingImageId)
+        
+        
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
@@ -78,8 +78,8 @@ class ProfileEditViewModel {
             .amb(existingImageId)
         
         // Edit Profile
-        let editData = profile
-            .withLatestFrom(imageID) { profile, imageID in
+        let editData = imageID
+            .withLatestFrom(profile) { imageID, profile in
                 return ProfileImageRequestEntity(imageId: imageID, profileRequest: profile)
             }
         

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileEdit/ProfileEditViewModel.swift
@@ -25,6 +25,8 @@ class ProfileEditViewModel {
     // ViewModel -> View
     let data = PublishRelay<ProfileResponseEntity>()
     let presentPickerView: Driver<Void>
+    let dismiss: Driver<ProfileResponseEntity>
+    
     
     init(_ model: ProfileEditModel = ProfileEditModel()) {
         data
@@ -74,6 +76,31 @@ class ProfileEditViewModel {
         let imageID = imageValue
             .amb(existingImageId)
         
+        // Edit Profile
+        let editData = profile
+            .withLatestFrom(imageID) { profile, imageID in
+                return ProfileImageRequestEntity(imageId: imageID, profileRequest: profile)
+            }
+        
+        let editResult = editData
+            .flatMap(model.editProfile)
+            .share()
+        
+        let editValue = editResult
+            .compactMap(model.editProfileValue)
+        
+        let editError = editResult
+            .compactMap(model.editProfileError)
+        
+        editError
+            .subscribe(onNext: {
+                print("Error: \($0)")
+            })
+            .disposed(by: disposeBag)
+        
+        // Dismiss ProfileEdit
+        dismiss = editValue
+            .asDriver(onErrorDriveWith: .empty())
         
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/ProfileMainViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Profile/ProfileMain/ProfileMainViewController.swift
@@ -53,9 +53,13 @@ class ProfileMainViewController: UIViewController {
             .disposed(by: disposeBag)
         
         viewModel.pushToProfileEdit
-            .drive(onNext: { viewModel in
+            .drive(onNext: { editViewModel in
                 let profileEditVC = ProfileEditViewController()
-                profileEditVC.bind(viewModel)
+                profileEditVC.bind(editViewModel)
+                
+                editViewModel.profileEdited
+                    .bind(to: viewModel.profileContentViewModel.profileDefaultViewModel.shouldBindProfile)
+                    .disposed(by: self.disposeBag)
                 
                 self.navigationController?.pushViewController(profileEditVC, animated: true)
             })


### PR DESCRIPTION
# 👩‍💻구현 내용
프로필 수정 화면 서버 연결

-  ProfileNetwork: 프로필 수정 Network 메서드 응답 타입 변경 및 응답 데이터 decoding

- 프로필 완료 버튼 이벤트
   - 프로필 이미지 변경 여부에 따른 서버 연결 로직 구현
      - 사진 미 선택 시 기존 이미지ID가 그대로 전달되도록 구현
      - 사진 선택 시 새로운 이미지를 서버에 업로드한 후 응답으로 온 이미지ID 전달되도록 구현
   - 프로필 데이터 수정 서버 연결 및 화면 dismiss

- 프로필 수정 후 변경된 프로필로 이전 화면인 프로필 메인에 데이터 반영

<br>
<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/0f3a7146-1b0a-4116-87ba-9864f450b049" width = 280 height = 550> |




<br>
#141 

