### PR TITLE
ClubDetail(모임 상세): 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
@@ -36,6 +36,9 @@ class ClubDetailViewController: UIViewController {
     
     func bind(_ viewModel: ClubDetailViewModel) {
         
+        // View -> ViewModel
+        viewModel.loadClubDetail.accept(Void())
+        
         // ViewModel -> View
         viewModel.cellData
             .drive(postTableview.rx.items(cellIdentifier: "ClubDetailTableViewCell", cellType: ClubDetailTableViewCell.self)) { row, element, cell in

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
@@ -45,16 +45,9 @@ class ClubDetailViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        viewModel.navigationTitle
-            .map({ d in
-                print(d)
-                return d
-            })
+        viewModel.clubName
             .bind(to: navigationItem.rx.title)
             .disposed(by: disposeBag)
-        
-        // 테스트용 코드
-        viewModel.navigationTitle.accept("원프 모임명")
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
@@ -19,7 +19,7 @@ struct ClubDetailViewModel {
     
     // ViewModel -> View
     let cellData: Driver<ClubPostListResponseEntity>
-    let navigationTitle = PublishRelay<String>()
+    let clubName = PublishRelay<String>()
     
     init() {
         cellData = Observable

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
@@ -15,6 +15,8 @@ struct ClubDetailViewModel {
     // SubcomponenetViewModel
     let cellViewModel = ClubDetailTableViewCellViewModel()
     
+    let id = PublishRelay<Int>()
+    
     // ViewModel -> View
     let cellData: Driver<ClubPostListResponseEntity>
     let navigationTitle = PublishRelay<String>()

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
@@ -15,13 +15,25 @@ struct ClubDetailViewModel {
     // SubcomponenetViewModel
     let cellViewModel = ClubDetailTableViewCellViewModel()
     
+    let disposeBag = DisposeBag()
     let id = PublishRelay<Int>()
+    
+    // View -> ViewModel
+    let loadClubDetail = PublishRelay<Void>()
     
     // ViewModel -> View
     let cellData: Driver<ClubPostListResponseEntity>
     let clubName = PublishRelay<String>()
     
     init() {
+        
+        // Load ClubDetail
+        loadClubDetail
+            .subscribe(onNext: {
+                print("Load")
+            })
+            .disposed(by: disposeBag)
+        
         cellData = Observable
             .just([
                 ClubPostResponseEntity(id: 0, createdDate: "2023-08-29T14:29:15.056216", nickname: "원프", content: "Table views in iOS display rows of vertically scrolling content in a single column. Each row in the table contains one piece of your app’s content. For example, the Contacts app displays the name of each contact in a separate row, and the main page of the Settings app displays the available groups of settings. You can configure a table to display a single long list of rows, or you can group related rows into sections to make navigating the content easier.", image: nil),

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableView.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableView.swift
@@ -42,6 +42,11 @@ class ClubListTableView: UITableView {
                     .disposed(by: self.disposeBag)
             }
             .disposed(by: disposeBag)
+        
+        self.rx.itemSelected
+            .bind(to: viewModel.didSelectItem)
+            .disposed(by: disposeBag)
+        
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewModel.swift
@@ -10,10 +10,15 @@ import Foundation
 import RxSwift
 import RxCocoa
 
+typealias ClubInfo = (id: Int, name: String)
+
 struct ClubListTableViewModel {
     
     // ParentViewModel -> ViewModel
     let shoulLoadClubs = PublishRelay<[ClubResponseEntity]>()
+    
+    // ViewModel -> ParentViewModel
+    let shouldPushToClubDetail: Signal<ClubInfo>
     
     // View -> ViewModel
     let shareButtonTapped = PublishRelay<ClubResponseEntity>()
@@ -26,5 +31,11 @@ struct ClubListTableViewModel {
     init() {
         cellData = shoulLoadClubs
             .asDriver(onErrorDriveWith: .empty())
+        
+        shouldPushToClubDetail = didSelectItem
+            .withLatestFrom(cellData, resultSelector: { indexPath, list in
+                ClubInfo(indexPath.row, list[indexPath.row].name)
+            })
+            .asSignal(onErrorSignalWith: .empty())
     }
 }

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListSubcomponents/ClubListTableViewModel.swift
@@ -17,6 +17,7 @@ struct ClubListTableViewModel {
     
     // View -> ViewModel
     let shareButtonTapped = PublishRelay<ClubResponseEntity>()
+    let didSelectItem = PublishRelay<IndexPath>()
     
     // ViewModel -> View
     let cellData: Driver<[ClubResponseEntity]>

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
@@ -80,6 +80,15 @@ class ClubListViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        viewModel.pushToClubDetail
+            .drive(onNext: { viewModel in
+                let clubDetailVC = ClubDetailViewController()
+                clubDetailVC.bind(viewModel)
+                
+                self.navigationController?.pushViewController(clubDetailVC, animated: true)
+            })
+            .disposed(by: disposeBag)
+        
     }
     
     func presentAddActionSheet(_ viewModel: ClubListViewModel) {

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewController.swift
@@ -81,10 +81,10 @@ class ClubListViewController: UIViewController {
             .disposed(by: disposeBag)
         
         viewModel.pushToClubDetail
-            .drive(onNext: { viewModel in
+            .drive(onNext: {
                 let clubDetailVC = ClubDetailViewController()
-                clubDetailVC.bind(viewModel)
-                
+                clubDetailVC.bind($0.viewModel)
+                $0.viewModel.clubName.accept($0.name)
                 self.navigationController?.pushViewController(clubDetailVC, animated: true)
             })
             .disposed(by: disposeBag)

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewModel.swift
@@ -35,6 +35,7 @@ struct ClubListViewModel {
     let presentCreateAlert: Driver<Void>
     let presentJoinAlert: Driver<Void>
     let presentShareActivity: Driver<ClubShareInfoEntity>
+    let pushToClubDetail: Driver<ClubDetailViewModel>
     
     init(_ model: ClubListModel = ClubListModel()) {
         
@@ -133,6 +134,16 @@ struct ClubListViewModel {
         
         // Present ShareActivity
         presentShareActivity = clubShareInfo
+            .asDriver(onErrorDriveWith: .empty())
+        
+        // Push to ClubDetail
+        pushToClubDetail = clubListTableViewModel.didSelectItem
+            .map {
+                let viewModel = ClubDetailViewModel()
+                viewModel.id.accept($0.row)
+                
+                return viewModel
+            }
             .asDriver(onErrorDriveWith: .empty())
         
         // Initialize Data

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubList/ClubListViewModel.swift
@@ -35,7 +35,7 @@ struct ClubListViewModel {
     let presentCreateAlert: Driver<Void>
     let presentJoinAlert: Driver<Void>
     let presentShareActivity: Driver<ClubShareInfoEntity>
-    let pushToClubDetail: Driver<ClubDetailViewModel>
+    let pushToClubDetail: Driver<(name: String, viewModel: ClubDetailViewModel)>
     
     init(_ model: ClubListModel = ClubListModel()) {
         
@@ -137,12 +137,11 @@ struct ClubListViewModel {
             .asDriver(onErrorDriveWith: .empty())
         
         // Push to ClubDetail
-        pushToClubDetail = clubListTableViewModel.didSelectItem
+        pushToClubDetail = clubListTableViewModel.shouldPushToClubDetail
             .map {
                 let viewModel = ClubDetailViewModel()
-                viewModel.id.accept($0.row)
-                
-                return viewModel
+                viewModel.id.accept($0.id)
+                return ($0.name, viewModel)
             }
             .asDriver(onErrorDriveWith: .empty())
         


### PR DESCRIPTION
# 👩‍💻구현 내용
모임 상세 기능 구현

- ClubList:
    - (모임 목록 -> 모임 상세) 화면 전환
    - 모임 ID, 모임명 데이터 전달
- ClubDetail:
    - 화면 로드 이벤트 전달
    - NavigationBar Title에 모임명 할당

<br>
<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/66bab4e4-f6a1-44e1-b2fc-4d02fd08fa5d" width = 280 height = 550> |



<br>
#149 

