### PR TITLE
ClubDetail(모임 상세): 이미지 유무에 따른 Cell 구분 - UI

### DIFF
--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 		149B95652ABDDB1F00AF7993 /* ClubDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95642ABDDB1F00AF7993 /* ClubDetailViewController.swift */; };
 		149B95672ABDDB4400AF7993 /* ClubDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95662ABDDB4400AF7993 /* ClubDetailViewModel.swift */; };
 		149B95692ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95682ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift */; };
-		149B956B2ABDDBC600AF7993 /* ClubDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B956A2ABDDBC600AF7993 /* ClubDetailTableViewCell.swift */; };
+		149B956B2ABDDBC600AF7993 /* ClubDetailListImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */; };
 		149F01622A13859600370FE1 /* DynamicSizeTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149F01612A13859600370FE1 /* DynamicSizeTableView.swift */; };
 		14A11A562A94AD76008453FC /* ProfileImageRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A11A552A94AD76008453FC /* ProfileImageRequestEntity.swift */; };
 		14A11A582A94BA07008453FC /* ExNSMutableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A11A572A94BA07008453FC /* ExNSMutableData.swift */; };
@@ -345,7 +345,7 @@
 		149B95642ABDDB1F00AF7993 /* ClubDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailViewController.swift; sourceTree = "<group>"; };
 		149B95662ABDDB4400AF7993 /* ClubDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailViewModel.swift; sourceTree = "<group>"; };
 		149B95682ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailTableViewCellViewModel.swift; sourceTree = "<group>"; };
-		149B956A2ABDDBC600AF7993 /* ClubDetailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailTableViewCell.swift; sourceTree = "<group>"; };
+		149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailListImageCell.swift; sourceTree = "<group>"; };
 		149F01612A13859600370FE1 /* DynamicSizeTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicSizeTableView.swift; sourceTree = "<group>"; };
 		14A11A552A94AD76008453FC /* ProfileImageRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageRequestEntity.swift; sourceTree = "<group>"; };
 		14A11A572A94BA07008453FC /* ExNSMutableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExNSMutableData.swift; sourceTree = "<group>"; };
@@ -1024,7 +1024,7 @@
 			isa = PBXGroup;
 			children = (
 				149B95682ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift */,
-				149B956A2ABDDBC600AF7993 /* ClubDetailTableViewCell.swift */,
+				149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */,
 			);
 			path = ClubDetailSubcomponents;
 			sourceTree = "<group>";
@@ -1403,7 +1403,7 @@
 				146EA3422A8B522C005E010B /* ProfileBarButtonItem.swift in Sources */,
 				14886B282AC1A656005F6E07 /* ClubDetailModel.swift in Sources */,
 				1466FA202A0A428D00910C30 /* AuthNetwork.swift in Sources */,
-				149B956B2ABDDBC600AF7993 /* ClubDetailTableViewCell.swift in Sources */,
+				149B956B2ABDDBC600AF7993 /* ClubDetailListImageCell.swift in Sources */,
 				14BD19F229FBB9EF00B0E598 /* ProfileContentKeywordListCell.swift in Sources */,
 				142DBED229DC223A00017603 /* EmailTextFieldViewModel.swift in Sources */,
 				149B95652ABDDB1F00AF7993 /* ClubDetailViewController.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		1415DD922AA1D0BE00EF03A4 /* MessageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */; };
 		1415DD942AA1D13A00EF03A4 /* MessageListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */; };
 		1415DD972AA1D81000EF03A4 /* MessageListResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1415DD962AA1D81000EF03A4 /* MessageListResponseEntity.swift */; };
+		1417FC002AC2774400613777 /* ClubDetailListTextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1417FBFF2AC2774400613777 /* ClubDetailListTextCell.swift */; };
 		141A781829D7ED46006731F7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781729D7ED46006731F7 /* AppDelegate.swift */; };
 		141A781A29D7ED46006731F7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141A781929D7ED46006731F7 /* SceneDelegate.swift */; };
 		141A782129D7ED46006731F7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 141A782029D7ED46006731F7 /* Assets.xcassets */; };
@@ -152,7 +153,7 @@
 		149B95612ABD62FC00AF7993 /* ClubPostResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95602ABD62FC00AF7993 /* ClubPostResponseEntity.swift */; };
 		149B95652ABDDB1F00AF7993 /* ClubDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95642ABDDB1F00AF7993 /* ClubDetailViewController.swift */; };
 		149B95672ABDDB4400AF7993 /* ClubDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95662ABDDB4400AF7993 /* ClubDetailViewModel.swift */; };
-		149B95692ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95682ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift */; };
+		149B95692ABDDBB200AF7993 /* ClubDetailListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95682ABDDBB200AF7993 /* ClubDetailListCellViewModel.swift */; };
 		149B956B2ABDDBC600AF7993 /* ClubDetailListImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */; };
 		149F01622A13859600370FE1 /* DynamicSizeTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149F01612A13859600370FE1 /* DynamicSizeTableView.swift */; };
 		14A11A562A94AD76008453FC /* ProfileImageRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A11A552A94AD76008453FC /* ProfileImageRequestEntity.swift */; };
@@ -226,6 +227,7 @@
 		1415DD912AA1D0BE00EF03A4 /* MessageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListViewController.swift; sourceTree = "<group>"; };
 		1415DD932AA1D13A00EF03A4 /* MessageListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListViewModel.swift; sourceTree = "<group>"; };
 		1415DD962AA1D81000EF03A4 /* MessageListResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListResponseEntity.swift; sourceTree = "<group>"; };
+		1417FBFF2AC2774400613777 /* ClubDetailListTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailListTextCell.swift; sourceTree = "<group>"; };
 		141A781429D7ED46006731F7 /* WanF-Project.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WanF-Project.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		141A781729D7ED46006731F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		141A781929D7ED46006731F7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -344,7 +346,7 @@
 		149B95602ABD62FC00AF7993 /* ClubPostResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubPostResponseEntity.swift; sourceTree = "<group>"; };
 		149B95642ABDDB1F00AF7993 /* ClubDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailViewController.swift; sourceTree = "<group>"; };
 		149B95662ABDDB4400AF7993 /* ClubDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailViewModel.swift; sourceTree = "<group>"; };
-		149B95682ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailListImageCellViewModel.swift; sourceTree = "<group>"; };
+		149B95682ABDDBB200AF7993 /* ClubDetailListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailListCellViewModel.swift; sourceTree = "<group>"; };
 		149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailListImageCell.swift; sourceTree = "<group>"; };
 		149F01612A13859600370FE1 /* DynamicSizeTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicSizeTableView.swift; sourceTree = "<group>"; };
 		14A11A552A94AD76008453FC /* ProfileImageRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageRequestEntity.swift; sourceTree = "<group>"; };
@@ -1023,8 +1025,9 @@
 		149B955D2ABD5E2300AF7993 /* ClubDetailSubcomponents */ = {
 			isa = PBXGroup;
 			children = (
-				149B95682ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift */,
+				149B95682ABDDBB200AF7993 /* ClubDetailListCellViewModel.swift */,
 				149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */,
+				1417FBFF2AC2774400613777 /* ClubDetailListTextCell.swift */,
 			);
 			path = ClubDetailSubcomponents;
 			sourceTree = "<group>";
@@ -1385,6 +1388,7 @@
 				143662002A0F7F0500308028 /* FriendsMatchNetwork.swift in Sources */,
 				144D30D92A068CE000640CCD /* SignUpNetwork.swift in Sources */,
 				14797C312A84BDD50006C706 /* ExReactive.swift in Sources */,
+				1417FC002AC2774400613777 /* ClubDetailListTextCell.swift in Sources */,
 				14F52BC22A8DEED800A09F92 /* ClubResponseEntity.swift in Sources */,
 				14567E9E29E00740000B75EE /* VerifiedStackViewCellViewModel.swift in Sources */,
 				14066BB329E166B100AFB2D2 /* SignUpPasswordModel.swift in Sources */,
@@ -1410,7 +1414,7 @@
 				149B95672ABDDB4400AF7993 /* ClubDetailViewModel.swift in Sources */,
 				148152802AAC7E50002F5830 /* MessageRequestEntity.swift in Sources */,
 				1415DD942AA1D13A00EF03A4 /* MessageListViewModel.swift in Sources */,
-				149B95692ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift in Sources */,
+				149B95692ABDDBB200AF7993 /* ClubDetailListCellViewModel.swift in Sources */,
 				14A11A582A94BA07008453FC /* ExNSMutableData.swift in Sources */,
 				1449E1F62A135375008C70DB /* FriendsMatchCommentListView.swift in Sources */,
 				1426B0542AB308D500E43EA1 /* RandomNetwork.swift in Sources */,

--- a/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
+++ b/WanF-Project/WanF-Project.xcodeproj/project.pbxproj
@@ -152,7 +152,7 @@
 		149B95612ABD62FC00AF7993 /* ClubPostResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95602ABD62FC00AF7993 /* ClubPostResponseEntity.swift */; };
 		149B95652ABDDB1F00AF7993 /* ClubDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95642ABDDB1F00AF7993 /* ClubDetailViewController.swift */; };
 		149B95672ABDDB4400AF7993 /* ClubDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95662ABDDB4400AF7993 /* ClubDetailViewModel.swift */; };
-		149B95692ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95682ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift */; };
+		149B95692ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B95682ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift */; };
 		149B956B2ABDDBC600AF7993 /* ClubDetailListImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */; };
 		149F01622A13859600370FE1 /* DynamicSizeTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149F01612A13859600370FE1 /* DynamicSizeTableView.swift */; };
 		14A11A562A94AD76008453FC /* ProfileImageRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A11A552A94AD76008453FC /* ProfileImageRequestEntity.swift */; };
@@ -344,7 +344,7 @@
 		149B95602ABD62FC00AF7993 /* ClubPostResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubPostResponseEntity.swift; sourceTree = "<group>"; };
 		149B95642ABDDB1F00AF7993 /* ClubDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailViewController.swift; sourceTree = "<group>"; };
 		149B95662ABDDB4400AF7993 /* ClubDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailViewModel.swift; sourceTree = "<group>"; };
-		149B95682ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailTableViewCellViewModel.swift; sourceTree = "<group>"; };
+		149B95682ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailListImageCellViewModel.swift; sourceTree = "<group>"; };
 		149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClubDetailListImageCell.swift; sourceTree = "<group>"; };
 		149F01612A13859600370FE1 /* DynamicSizeTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicSizeTableView.swift; sourceTree = "<group>"; };
 		14A11A552A94AD76008453FC /* ProfileImageRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageRequestEntity.swift; sourceTree = "<group>"; };
@@ -1023,7 +1023,7 @@
 		149B955D2ABD5E2300AF7993 /* ClubDetailSubcomponents */ = {
 			isa = PBXGroup;
 			children = (
-				149B95682ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift */,
+				149B95682ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift */,
 				149B956A2ABDDBC600AF7993 /* ClubDetailListImageCell.swift */,
 			);
 			path = ClubDetailSubcomponents;
@@ -1410,7 +1410,7 @@
 				149B95672ABDDB4400AF7993 /* ClubDetailViewModel.swift in Sources */,
 				148152802AAC7E50002F5830 /* MessageRequestEntity.swift in Sources */,
 				1415DD942AA1D13A00EF03A4 /* MessageListViewModel.swift in Sources */,
-				149B95692ABDDBB200AF7993 /* ClubDetailTableViewCellViewModel.swift in Sources */,
+				149B95692ABDDBB200AF7993 /* ClubDetailListImageCellViewModel.swift in Sources */,
 				14A11A582A94BA07008453FC /* ExNSMutableData.swift in Sources */,
 				1449E1F62A135375008C70DB /* FriendsMatchCommentListView.swift in Sources */,
 				1426B0542AB308D500E43EA1 /* RandomNetwork.swift in Sources */,

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListCellViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  ClubDetailListImageCellViewModel.swift
+//  ClubDetailListCellViewModel.swift
 //  WanF-Project
 //
 //  Created by 임윤휘 on 2023/09/22.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class ClubDetailListImageCellViewModel {
+class ClubDetailListCellViewModel {
     
     // Subcomponenet ViewModel
     let detailInfoViewModel = PostUserInfoControlViewModel()

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListImageCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListImageCell.swift
@@ -1,5 +1,5 @@
 //
-//  ClubDetailTableViewCell.swift
+//  ClubDetailListImageCell.swift
 //  WanF-Project
 //
 //  Created by 임윤휘 on 2023/09/22.
@@ -11,7 +11,7 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-class ClubDetailTableViewCell: UITableViewCell {
+class ClubDetailListImageCell: UITableViewCell {
     
     //MARK: - Propertied
     var viewModel: ClubDetailTableViewCellViewModel?
@@ -72,7 +72,7 @@ class ClubDetailTableViewCell: UITableViewCell {
 }
 
 //MARK: - Configure
-private extension ClubDetailTableViewCell {
+private extension ClubDetailListImageCell {
     func configure() {
         backgroundColor = .wanfBackground
         

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListImageCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListImageCell.swift
@@ -14,7 +14,7 @@ import RxCocoa
 class ClubDetailListImageCell: UITableViewCell {
     
     //MARK: - Propertied
-    var viewModel: ClubDetailTableViewCellViewModel?
+    var viewModel: ClubDetailListImageCellViewModel?
     
     //MARK: - View
     private lazy var detailInfoControl = PostUserInfoControlView()
@@ -48,7 +48,7 @@ class ClubDetailListImageCell: UITableViewCell {
 
     
     //MARK: - function
-    func bind(_ viewModel: ClubDetailTableViewCellViewModel) {
+    func bind(_ viewModel: ClubDetailListImageCellViewModel) {
         self.viewModel = viewModel
         
         // Bind Subcomponent ViewModel

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListImageCellViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListImageCellViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  ClubDetailTableViewCellViewModel.swift
+//  ClubDetailListImageCellViewModel.swift
 //  WanF-Project
 //
 //  Created by 임윤휘 on 2023/09/22.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class ClubDetailTableViewCellViewModel {
+class ClubDetailListImageCellViewModel {
     
     // Subcomponenet ViewModel
     let detailInfoViewModel = PostUserInfoControlViewModel()

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListTextCell.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailSubcomponents/ClubDetailListTextCell.swift
@@ -1,8 +1,8 @@
 //
-//  ClubDetailListImageCell.swift
+//  ClubDetailListTextCell.swift
 //  WanF-Project
 //
-//  Created by 임윤휘 on 2023/09/22.
+//  Created by 임윤휘 on 2023/09/26.
 //
 
 import UIKit
@@ -11,7 +11,7 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-class ClubDetailListImageCell: UITableViewCell {
+class ClubDetailListTextCell: UITableViewCell {
     
     //MARK: - Propertied
     var viewModel: ClubDetailListCellViewModel?
@@ -26,12 +26,6 @@ class ClubDetailListImageCell: UITableViewCell {
         label.numberOfLines = 0
         
         return label
-    }()
-    private lazy var contentImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleToFill
-        
-        return imageView
     }()
     
     //MARK: - LifeCycle
@@ -58,28 +52,17 @@ class ClubDetailListImageCell: UITableViewCell {
     func configureCell(_ post: ClubPostResponseEntity) {
         viewModel?.detailInfoViewModel.detailInfo.accept((post.nickname, post.createdDate))
         self.contentLabel.text = post.content
-        self.contentImageView.image = UIImage(named: "WanfIcon_240")
-        
-        if let urlString = post.image?.imageUrl {
-            let url = URL(string: urlString)
-            url?.image({ image in
-                DispatchQueue.main.async {
-                    self.contentImageView.image = image
-                }
-            })
-        }
     }
 }
 
 //MARK: - Configure
-private extension ClubDetailListImageCell {
+private extension ClubDetailListTextCell {
     func configure() {
         backgroundColor = .wanfBackground
         
         [
             detailInfoControl,
-            contentLabel,
-            contentImageView
+            contentLabel
         ]
             .forEach { contentView.addSubview($0) }
     }
@@ -98,19 +81,10 @@ private extension ClubDetailListImageCell {
         contentLabel.snp.makeConstraints { make in
             make.top.equalTo(detailInfoControl.snp.bottom).offset(offset).priority(.high)
             make.left.equalToSuperview().inset(horizontalInset)
+            make.bottom.equalToSuperview().inset(verticalInset)
             
             make.width.equalTo(self).inset(horizontalInset * 2)
         }
-        
-        contentImageView.snp.makeConstraints { make in
-            make.top.equalTo(contentLabel.snp.bottom).offset(offset)
-            make.horizontalEdges.equalToSuperview().inset(horizontalInset)
-            make.bottom.equalToSuperview().inset(verticalInset)
-            
-            make.width.equalTo(self).inset(horizontalInset * 2).priority(.high)
-            make.height.equalTo(contentImageView.snp.width)
-        }
-        
     }
 }
 

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
@@ -51,6 +51,7 @@ class ClubDetailViewController: UIViewController {
                     
                     cell.bind(viewModel)
                     cell.configureCell(element)
+                    cell.selectionStyle = .none
                     return cell
                 }
                 else { // Text
@@ -59,6 +60,7 @@ class ClubDetailViewController: UIViewController {
                     
                     cell.bind(viewModel)
                     cell.configureCell(element)
+                    cell.selectionStyle = .none
                     return cell
                 }
             }

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
@@ -23,6 +23,7 @@ class ClubDetailViewController: UIViewController {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 100
         tableView.register(ClubDetailListImageCell.self, forCellReuseIdentifier: "ClubDetailListImageCell")
+        tableView.register(ClubDetailListTextCell.self, forCellReuseIdentifier: "ClubDetailListTextCell")
         
         return tableView
     }()
@@ -41,10 +42,25 @@ class ClubDetailViewController: UIViewController {
         
         // ViewModel -> View
         viewModel.cellData
-            .drive(postTableview.rx.items(cellIdentifier: "ClubDetailListImageCell", cellType: ClubDetailListImageCell.self)) { row, element, cell in
-                cell.bind(viewModel.cellViewModel)
-                cell.configureCell(element)
-                cell.selectionStyle = .none
+            .drive(postTableview.rx.items) { (tableView, row, element) -> UITableViewCell  in
+                let viewModel = ClubDetailListCellViewModel()
+                
+                if element.image != nil { // Image
+                    guard let cell = tableView.dequeueReusableCell(withIdentifier: "ClubDetailListImageCell") as? ClubDetailListImageCell
+                    else { return UITableViewCell() }
+                    
+                    cell.bind(viewModel)
+                    cell.configureCell(element)
+                    return cell
+                }
+                else { // Text
+                    guard let cell = tableView.dequeueReusableCell(withIdentifier: "ClubDetailListTextCell") as? ClubDetailListTextCell
+                    else { return UITableViewCell() }
+                    
+                    cell.bind(viewModel)
+                    cell.configureCell(element)
+                    return cell
+                }
             }
             .disposed(by: disposeBag)
         

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewController.swift
@@ -22,7 +22,7 @@ class ClubDetailViewController: UIViewController {
         var tableView = UITableView()
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 100
-        tableView.register(ClubDetailTableViewCell.self, forCellReuseIdentifier: "ClubDetailTableViewCell")
+        tableView.register(ClubDetailListImageCell.self, forCellReuseIdentifier: "ClubDetailListImageCell")
         
         return tableView
     }()
@@ -41,7 +41,7 @@ class ClubDetailViewController: UIViewController {
         
         // ViewModel -> View
         viewModel.cellData
-            .drive(postTableview.rx.items(cellIdentifier: "ClubDetailTableViewCell", cellType: ClubDetailTableViewCell.self)) { row, element, cell in
+            .drive(postTableview.rx.items(cellIdentifier: "ClubDetailListImageCell", cellType: ClubDetailListImageCell.self)) { row, element, cell in
                 cell.bind(viewModel.cellViewModel)
                 cell.configureCell(element)
                 cell.selectionStyle = .none

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
@@ -13,7 +13,7 @@ import RxCocoa
 struct ClubDetailViewModel {
     
     // SubcomponenetViewModel
-    let cellViewModel = ClubDetailListImageCellViewModel()
+    let cellViewModel = ClubDetailListCellViewModel()
     
     let disposeBag = DisposeBag()
     let id = PublishRelay<Int>()

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
@@ -12,9 +12,6 @@ import RxCocoa
 
 struct ClubDetailViewModel {
     
-    // SubcomponenetViewModel
-    let cellViewModel = ClubDetailListCellViewModel()
-    
     let disposeBag = DisposeBag()
     let id = PublishRelay<Int>()
     

--- a/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/Club/ClubDetail/ClubDetailViewModel.swift
@@ -13,7 +13,7 @@ import RxCocoa
 struct ClubDetailViewModel {
     
     // SubcomponenetViewModel
-    let cellViewModel = ClubDetailTableViewCellViewModel()
+    let cellViewModel = ClubDetailListImageCellViewModel()
     
     let disposeBag = DisposeBag()
     let id = PublishRelay<Int>()


### PR DESCRIPTION
# 👩‍💻구현 내용
모임 상세 게시글의 이미지 유무에 따른 Cell 생성 및 적용

-  이미지 유무에 따른 Cell 생성
   - ClubDetailListImageCell
   - ClubDetailListTextCell
   - ClubDetailListCellViewModel: 두 타입의 Cell 모두 사용
- 이미지 유무에 따라 Cell 구분하여 적용

<br>
<br>
<br>

| 미리 보기 |
| ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/c8fe3d0a-3e00-4b44-bc6b-70ac54bedfac" width = 280 height = 550> |



<br>
#153 

