### PR TITLE
FriendsMatchList: 배너 URL 이벤트 기능 구현

### DIFF
--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
@@ -76,11 +76,15 @@ class FriendsMatchTabViewController: UIViewController {
             .disposed(by: disposeBag)
         
         friednsMultipleListView.rx.itemSelected
-            .map {
-                viewModel.loadDetailSubject.onNext(viewModel.loadDetailForSelectedItem)
-                return $0.row
-            }
-            .bind(to: viewModel.didSelectItem)
+            .subscribe(onNext: { indexPath in
+                switch self.friednsMultipleListView.types[indexPath.section] {
+                case .bannerSection:
+                    viewModel.didSelectBanner.accept(indexPath.row)
+                case .postSection:
+                    viewModel.loadDetailSubject.onNext(viewModel.loadDetailForSelectedItem)
+                    viewModel.didSelectPost.accept(indexPath.row)
+                }
+            })
             .disposed(by: disposeBag)
         
         // ViewModel -> View

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewController.swift
@@ -126,6 +126,14 @@ class FriendsMatchTabViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        viewModel.openInSafari
+            .drive(onNext: { url in
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url)
+                }
+            })
+            .disposed(by: disposeBag)
+        
         bindListView(viewModel)
     }
     

--- a/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewModel.swift
+++ b/WanF-Project/WanF-Project/Presentation/FriendsMatch/FriendsMatchTab/FriendsMatchTabViewModel.swift
@@ -29,7 +29,8 @@ class FriendsMatchTabViewModel {
     let loadDetailForNotification = PublishSubject<Int>()
     var loadDetailForSelectedItem = PublishSubject<Int>()
     let didTapNotification = PublishRelay<Int>()
-    let didSelectItem = PublishRelay<Int>()
+    let didSelectPost = PublishRelay<Int>()
+    let didSelectBanner = PublishRelay<Int>()
     
     // ViewModel -> View
     let multipleCellData: Driver<[MultipleSectionModel]>
@@ -39,6 +40,7 @@ class FriendsMatchTabViewModel {
     let pushToSearch: Driver<FriendsMatchSearchViewModel>
     let presentFriendsMatchWriting: Driver<FriendsMatchWritingViewModel>
     let pushToFriendsMatchDetail: Driver<FriendsMatchDetailViewModel>
+    let openInSafari: Driver<URL>
     
     init(_ model: FriendsMatchTabModel = FriendsMatchTabModel()) {
         
@@ -82,7 +84,9 @@ class FriendsMatchTabViewModel {
         let loadBannerValue = loadBannerResult
             .compactMap(model.loadBannersValue)
         
-        let bannerCellData = loadBannerValue
+        let banners = loadBannerValue
+        
+        let bannerCellData = banners
             .map { banners in
                 MultipleSectionModel.BannerSection(items: banners.map { SectionItem.BannerItem($0) })
             }
@@ -102,7 +106,7 @@ class FriendsMatchTabViewModel {
             .asDriver(onErrorDriveWith: .empty())
         
         // Load Detail
-        didSelectItem
+        didSelectPost
             .withLatestFrom(postData, resultSelector: { index, posts in
                 posts[index].id
             })
@@ -118,6 +122,14 @@ class FriendsMatchTabViewModel {
             .map {
                 FriendsMatchDetailViewModel(id: $0)
             }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        // Load Banner URL in Safari
+        openInSafari = didSelectBanner
+            .withLatestFrom(banners) { row, banners in
+                banners[row].url
+            }
+            .compactMap { URL(string: $0) }
             .asDriver(onErrorDriveWith: .empty())
         
         // Initialize


### PR DESCRIPTION
# 👩‍💻구현 내용
강의 친구 찾기 화면의 배너 선택 시 사파리 URL 로드

-  게시글 목록과 배너 목록 아이템 선택 이벤트 구분
- 배너 아이템 선택 시 사파리 URL 로드

<br>
<br>
<br>

| 미리 보기 | 시연 |
| ----- | ----- |
| <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/3ab783e6-beee-4878-af41-937a07464ca8" width = 350 height = 750> | <img src = "https://github.com/WanF-Project/WanF-Project-iOS/assets/65601189/b19f4d3a-3c72-4ff7-b162-9d330a85b900" width = 350 height = 750> |



<br>
#171 

